### PR TITLE
use newer clean-deep that removes empty arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "cli.js",
   "dependencies": {
     "cheerio": "^0.22.0",
-    "clean-deep": "0.0.1",
+    "clean-deep": "github:zeke/clean-deep",
     "decamelize": "^1.2.0",
     "dedent": "^0.6.0",
     "electron-docs": "^1.1.0",

--- a/test/index.js
+++ b/test/index.js
@@ -224,6 +224,12 @@ describe('APIs', function () {
       expect(apis.NativeImage.instanceMethods.toJPEG.signature).to.eq('(quality)')
     })
 
+    they('do not have a parameters array if they do not take parameters', function () {
+      var method = JSON.parse(JSON.stringify(apis.BrowserWindowProxy.instanceMethods.blur))
+      expect(method.name).to.equal('blur')
+      expect(method.parameters).to.be.undefined
+    })
+
     they('can have a platform array', function () {
       expect(apis.BrowserWindow.instanceMethods.setAspectRatio.platforms[0]).to.eq('macOS')
     })
@@ -261,6 +267,12 @@ describe('APIs', function () {
         expect(props.every(prop => prop.name.length > 0)).to.be.true
         expect(props.every(prop => prop.description.length > 0)).to.be.true
       })
+    })
+
+    they('are absent from APIs that have no instance properties', function () {
+      var api = JSON.parse(JSON.stringify(apis.NativeImage))
+      expect(api.name).to.equal('NativeImage')
+      expect(api.instanceProperties).to.be.undefined
     })
 
     they('have properly parsed name and description', function () {


### PR DESCRIPTION
This recursively removes all empty arrays from the schema.

Using my branch of `clean-deep` until https://github.com/seegno/clean-deep/pull/5 is released.

These are all gone now:

```
"platforms": [],
    "possibleValues": []
"platforms": [],
    "possibleValues": []
"platforms": [],
    "possibleValues": []
"platforms": [],
    "possibleValues": []
"platforms": [],
    "possibleValues": []
"platforms": [],
"parameters": []
"platforms": [],
"parameters": []
"events": []
"staticMethods": [],
"platforms": [],
"parameters": []
"platforms": [],
"parameters": []
"platforms": [],
    "possibleValues": []
"platforms": [],
"parameters": []
"platforms": [],
"parameters": []
"platforms": [],
    "possibleValues": []
    "possibleValues": []
"instanceEvents": []
```