### PR TITLE
Remove undef returns

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -80,7 +80,7 @@ module.exports = {
         properties = generateObjectProps($, props, api)
       }
     }
-    if (type === 'undefined') return undefined
+    if (type === 'undefined') return
     return {
       type,
       description: sanitizeDescription(description),

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -80,6 +80,7 @@ module.exports = {
         properties = generateObjectProps($, props, api)
       }
     }
+    if (type === 'undefined') return undefined
     return {
       type,
       description: sanitizeDescription(description),

--- a/test/index.js
+++ b/test/index.js
@@ -349,8 +349,7 @@ describe('APIs', function () {
 
   describe('Deep objects', function () {
     it('resolve deep objects as return values', function () {
-      const api = apis.find(a => a.name === 'webFrame')
-      const method = api.methods.find(m => m.name === 'getResourceUsage')
+      const method = apis.webFrame.methods.getResourceUsage
       expect(method.returns.type).to.equal('Object')
       expect(method.returns.properties.length).to.equal(5)
       method.returns.properties.forEach(prop => {
@@ -358,6 +357,19 @@ describe('APIs', function () {
         expect(prop.properties.length).to.equal(6)
       })
       // console.log(JSON.stringify(method, null, 4))
+    })
+  })
+
+  describe('Returns', function () {
+    it('should set return types for methods that return a value', function () {
+      const method = apis.app.methods.getName
+      expect(method.returns).to.not.equal(undefined)
+      expect(method.returns.type).to.equal('String')
+    })
+
+    it('should not set return types for methods that return undefined', function () {
+      const method = apis.app.methods.setName
+      expect(method.returns).to.equal(undefined)
     })
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -363,13 +363,13 @@ describe('APIs', function () {
   describe('Returns', function () {
     it('should set return types for methods that return a value', function () {
       const method = apis.app.methods.getName
-      expect(method.returns).to.not.equal(undefined)
+      expect(method.returns).to.exist
       expect(method.returns.type).to.equal('String')
     })
 
     it('should not set return types for methods that return undefined', function () {
       const method = apis.app.methods.setName
-      expect(method.returns).to.equal(undefined)
+      expect(method.returns).to.be.undefined
     })
   })
 })


### PR DESCRIPTION
Fixes #49

If the return type is `undefined` we don't set the `returns` object.

/cc @zeke 