### PR TITLE
Update clean deep

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -2,7 +2,7 @@
 
 const decamelize = require('decamelize')
 const marky = require('marky-markdown-lite')
-const omitEmpty = require('clean-deep')
+const cleanDeep = require('clean-deep')
 const pick = require('lodash.pick')
 const toMarkdown = require('to-markdown')
 const revalidator = require('revalidator')
@@ -102,7 +102,7 @@ class API {
       'properties'
     ]
 
-    return omitEmpty(pick(this, props))
+    return cleanDeep(pick(this, props))
   }
 
   parseDoc (docs) {

--- a/lib/collection-item.js
+++ b/lib/collection-item.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const omitEmpty = require('clean-deep')
+const cleanDeep = require('clean-deep')
 const pick = require('lodash.pick')
 const parsers = require('./parsers')
 const assert = require('assert')
@@ -33,7 +33,7 @@ module.exports = class CollectionItem {
   // When stringifying, only include the properties that are explicitly
   // specified in this.props
   toJSON () {
-    return omitEmpty(pick(this, this.props))
+    return cleanDeep(pick(this, this.props))
   }
 
   fail () {

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const cheerio = require('cheerio')
-const omitEmpty = require('clean-deep')
+const cleanDeep = require('clean-deep')
 const entities = require('entities')
 
 const parameterPattern = /<code>(\w+)<\/code>\s*(?:<a href.*>)?([a-zA-Z0-9\[\]]+)(?:<\/a>)?(?: - )?([\s\S]*)/m
@@ -177,7 +177,7 @@ module.exports = {
           if (!arg.possibleValues.length) delete arg.possibleValues
         }
 
-        return omitEmpty(arg)
+        return cleanDeep(arg)
       })
       .get()
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "cli.js",
   "dependencies": {
     "cheerio": "^0.22.0",
-    "clean-deep": "github:zeke/clean-deep",
+    "clean-deep": "^2.0.0",
     "decamelize": "^1.2.0",
     "dedent": "^0.6.0",
     "electron-docs": "^1.2.3",


### PR DESCRIPTION
https://github.com/seegno/clean-deep/releases/tag/v2.0.0 is out with support for cleaning empty arrays, so we don't need to use my fork any more.

Thanks, @seegno.