### PR TITLE
Param non greedy regexp

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -4,7 +4,7 @@ const cheerio = require('cheerio')
 const cleanDeep = require('clean-deep')
 const entities = require('entities')
 
-const parameterPattern = /<code>(\w+)<\/code>\s*(?:<a href.*>)?([a-zA-Z0-9\[\]]+)(?:<\/a>)?(?: - )?([\s\S]*)/m
+const parameterPattern = /<code>(\w+?)<\/code>\s*(?:<a href.*?>)?([a-zA-Z0-9\[\]]+)(?:<\/a>)?(?: - )?([\s\S]*)/m
 const methodReturnPattern = /^Returns (<a.+?>)?<code>(.*?)<\/code>(<\/a>)?/g
 
 const textify = ($, things) => {

--- a/test/index.js
+++ b/test/index.js
@@ -382,6 +382,12 @@ describe('APIs', function () {
         expect(prop.type).to.equal('MemoryUsageDetails')
       })
     })
+
+    it('resolves properties of objects as arrays correctly', function () {
+      const method = apis.app.methods.getJumpListSettings
+      expect(method.returns.type).to.equal('Object')
+      expect(method.returns.properties[1].type).to.equal('JumpListItem[]')
+    })
   })
 
   describe('Returns', function () {


### PR DESCRIPTION
This fixes a small issue where the structure link would be greedy and find an incorrect type in the description instead of the actual type declaration

/cc @zeke 