### PR TITLE
Multi type values

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -4,9 +4,21 @@ const cheerio = require('cheerio')
 const cleanDeep = require('clean-deep')
 const entities = require('entities')
 
-const parameterPattern = /<code>(\w+?)<\/code>\s*(?:<a href.*?>)?([a-zA-Z0-9\[\]]+)(?:<\/a>)?(?: - )?([\s\S]*)/m
+const parameterPattern = /<code>(\w+?)<\/code>\s*\(?((?:(?:<a href.*?>)?[a-zA-Z0-9\[\]]+(?:<\/a>)?(?: \| )?)+)\)?(?: - )?([\s\S]*)/m
 const methodReturnPattern = /^Returns (<a.+?>)?<code>(.*?)<\/code>(<\/a>)?/g
+const multiTypePattern = /(?:<a href.*?>)?([a-zA-Z0-9\[\]]+)(?:<\/a>)?(?: \| )?/mg
 
+const multitypify = (typeString) => {
+  const types = []
+  let t = multiTypePattern.exec(typeString)
+  while (t) {
+    types.push(t[1])
+    t = multiTypePattern.exec(typeString)
+  }
+  multiTypePattern.lastIndex = 0
+  // If there is one type, return as a string, else return an array of all the types
+  return types.length === 1 ? types[0] : types
+}
 const textify = ($, things) => {
   return things.map((i, el) => $(el).text())
     .get()
@@ -41,7 +53,7 @@ const generateObjectProps = ($, topUL, api) => {
 
       const ret = {
         name: match[1],
-        type: match[2],
+        type: multitypify(match[2]),
         description: sanitizeDescription(description)
       }
       if (ret.type === 'Object') {
@@ -139,7 +151,7 @@ module.exports = {
 
         var arg = {
           name: match[1],
-          type: match[2],
+          type: multitypify(match[2]),
           description: sanitizeDescription(description)
         }
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "update-electron": "git submodule update --recursive --init",
     "generate": "node cli.js vendor/electron --version=1.4.1 --outfile=electron.json && open electron.json",
-    "test": "mocha test/index.js && mocha test/cli.js && standard"
+    "test": "mocha test/*.js && standard"
   },
   "standard": {
     "env": {

--- a/test/errors.js
+++ b/test/errors.js
@@ -50,4 +50,12 @@ describe('Malformed Docs', function () {
     expect(errors[0].filename).to.equal('web-contents.md')
     expect(errors[0].html).to.equal('<code>HTMLOnly</code>')
   })
+
+  // TODO: Move this to "index.js" tests when an appropriate PR is merged into Electron
+  it('supports return types consisting of multiple types', function () {
+    var methodParam = apis.app.methods.setBadgeCount.parameters[0]
+    expect(methodParam.type).to.be.a('array')
+    expect(methodParam.type.length).to.equal(4)
+    expect(methodParam.type).to.deep.equal(['Integer', 'Number', 'Float', 'Struct'])
+  })
 })

--- a/test/fixtures/malformed/app.md
+++ b/test/fixtures/malformed/app.md
@@ -626,7 +626,7 @@ This method can only be called before app is ready.
 
 ### `app.setBadgeCount(count)` _Linux_ _macOS_
 
-* `count` Integer
+* `count` (Integer | Number | Float | [Struct](struct))
 
 Sets the counter badge for current app. Setting the count to `0` will hide the
 badge. Returns `true` when the call succeeded, otherwise returns `false`.


### PR DESCRIPTION
Required for https://github.com/electron/electron/pull/7540

Basically if there are multiple "type" values instead of "type" being a string, it becomes an array of all possible types.

Not sure if this is the correct approach or if we should change it to be `types` if it is an array

/cc @zeke 