### PR TITLE
Attempt to parse inline string ENUMS in prop descriptions

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -37,6 +37,7 @@ const sanitizeDescription = (description) => {
     .trim()
   )
 }
+const preserveBackTicks = (str) => str.replace(/<\/?code>/g, '`')
 const getPossibleValues = ($, el, description, api) => {
   const enumPattern = /<code>([-\w]+)<\/code>\s*(?: - )([\s\S]*)/
   let possibleValues = $(el)
@@ -105,7 +106,7 @@ const generateObjectProps = ($, topUL, api) => {
         }
       }
       if (ret.type === 'String') {
-        possibleValues = getPossibleValues($, el, sanitizeDescription($(el).html().replace(/<code>/g, '`').replace(/<\/code>/g, '`')), api)
+        possibleValues = getPossibleValues($, el, sanitizeDescription(preserveBackTicks($(el).html())), api)
         if (!possibleValues.length) possibleValues = null
       }
       if (properties) ret.properties = properties
@@ -186,7 +187,7 @@ module.exports = {
         if (!match) return api.addError('parameters', parameterPattern, $(el))
 
         // Preserve backticks
-        var description = match[3].replace(/<\/?code>/g, '`')
+        var description = preserveBackTicks(match[3])
 
         // Convert any lingering HTML to text
         description = cheerio.load(`<foo>${description}</foo>`)('foo')

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -37,6 +37,38 @@ const sanitizeDescription = (description) => {
     .trim()
   )
 }
+const getPossibleValues = ($, el, description, api) => {
+  const enumPattern = /<code>([-\w]+)<\/code>\s*(?: - )([\s\S]*)/
+  let possibleValues = $(el)
+    .find('li')
+    .map((i, el) => {
+      var match = $(el).html().match(enumPattern)
+      if (!match) return api.addError('parameter ENUM values', enumPattern, $(el))
+      return {
+        value: match[1],
+        description: sanitizeDescription(match[2])
+      }
+    })
+    .get()
+  if (possibleValues.length) return possibleValues
+  if (!description) return []
+
+  const inlineValuesPattern = /(?:can be|values include) ((?:(?:`[a-zA-Z\-]+`)(?:, ))*(?:`[a-zA-Z\-]+`)?(?: (?:or|and) `[a-zA-Z\-]+`)?)/i
+  const inlineMatch = inlineValuesPattern.exec(description)
+  if (inlineMatch) {
+    const valueString = inlineMatch[1]
+    const valuePattern = /`([a-zA-Z\-]+)`/g
+    let value = valuePattern.exec(valueString)
+
+    while (value) {
+      possibleValues.push({
+        value: value[1]
+      })
+      value = valuePattern.exec(valueString)
+    }
+  }
+  return possibleValues
+}
 const generateObjectProps = ($, topUL, api) => {
   return topUL.find('> li')
     .map((i, el) => {
@@ -44,6 +76,7 @@ const generateObjectProps = ($, topUL, api) => {
       if (!match) return api.addError('parameter subproperties', parameterPattern, $(el))
       let parameters
       let properties
+      let possibleValues
       let description = match[3]
 
       // Convert any lingering HTML to text
@@ -71,8 +104,13 @@ const generateObjectProps = ($, topUL, api) => {
           parameters = generateObjectProps($, innerParams, api, true)
         }
       }
+      if (ret.type === 'String') {
+        possibleValues = getPossibleValues($, el, sanitizeDescription($(el).html().replace(/<code>/g, '`').replace(/<\/code>/g, '`')), api)
+        if (!possibleValues.length) possibleValues = null
+      }
       if (properties) ret.properties = properties
       if (parameters) ret.parameters = parameters
+      if (possibleValues) ret.possibleValues = possibleValues
       return ret
     })
     .get()
@@ -128,8 +166,6 @@ module.exports = {
 
   // Find parameters in the first <ul> in the swath
   parameters: ($, openingHeadingElement, api) => {
-    const enumPattern = /<code>([-\w]+)<\/code>\s*(?: - )([\s\S]*)/
-
     const mSwath = swath($, openingHeadingElement)
 
     return mSwath
@@ -186,17 +222,7 @@ module.exports = {
         // Parse string sublists as ENUM values
         // e.g. apis.WebContents.instanceMethods.savePage.parameters.saveType.possibleValues
         if (arg.type === 'String') {
-          arg.possibleValues = $(el)
-            .find('li')
-            .map((i, el) => {
-              var match = $(el).html().match(enumPattern)
-              if (!match) return api.addError('parameter ENUM values', enumPattern, $(el))
-              return {
-                value: match[1],
-                description: sanitizeDescription(match[2])
-              }
-            })
-            .get()
+          arg.possibleValues = getPossibleValues($, el, arg.description, api)
 
           if (!arg.possibleValues.length) delete arg.possibleValues
         }

--- a/test/cli.js
+++ b/test/cli.js
@@ -22,7 +22,7 @@ describe('CLI', function () {
     expect(classes.every(api => api.instanceName.length > 0)).to.equal(true)
 
     // clean up
-    // rimraf(path.join(__dirname, 'electron.json'))
+    rimraf(path.join(__dirname, 'electron.json'))
   })
 
   it('prints errors to STDERR', function (done) {

--- a/test/cli.js
+++ b/test/cli.js
@@ -22,14 +22,14 @@ describe('CLI', function () {
     expect(classes.every(api => api.instanceName.length > 0)).to.equal(true)
 
     // clean up
-    rimraf(path.join(__dirname, 'electron.json'))
+    // rimraf(path.join(__dirname, 'electron.json'))
   })
 
   it('prints errors to STDERR', function (done) {
     exec('node ' + path.join(__dirname, '../cli.js test/fixtures/malformed'), function (err, stdout, stderr) {
       expect(err).to.exist
       expect(stderr).to.include('uh-oh! bad docs')
-      expect(stderr).to.include('5 errors found')
+      expect(stderr).to.include('7 errors found')
       done()
     })
   })

--- a/test/errors.js
+++ b/test/errors.js
@@ -45,10 +45,10 @@ describe('Malformed Docs', function () {
 
   it('method parameter ENUM values', function () {
     var errors = apis.WebContents.errors
-    expect(errors.length).to.equal(2)
-    expect(errors[1].type).to.equal('parameter ENUM values')
-    expect(errors[1].filename).to.equal('web-contents.md')
-    expect(errors[1].html).to.equal('<code>HTMLOnly</code>')
+    expect(errors.length).to.equal(4)
+    expect(errors[3].type).to.equal('parameter ENUM values')
+    expect(errors[3].filename).to.equal('web-contents.md')
+    expect(errors[3].html).to.equal('<code>HTMLOnly</code>')
   })
 
   // TODO: Move this to "index.js" tests when an appropriate PR is merged into Electron

--- a/test/index.js
+++ b/test/index.js
@@ -187,6 +187,12 @@ describe('APIs', function () {
       expect(possibleValue.description).to.include('Keeps system and screen active')
     })
 
+    they('can have possible values that are declared inline', function () {
+      var possibleValues = apis.WebContents.instanceMethods.openDevTools.parameters[0].properties[0].possibleValues
+      expect(possibleValues.length).to.equal(4)
+      expect(possibleValues.map(v => v.value)).to.deep.equal(['right', 'bottom', 'undocked', 'detach'])
+    })
+
     they('do not always have an ENUM of possible values', function () {
       var param = apis.clipboard.methods.writeHTML.parameters.markup
       expect(param.name).to.equal('markup')


### PR DESCRIPTION
This parses a common language syntax for string values that we are using relatively consistently throughout the docs.

Instead of changing the nice common language way to a formatted list that doesn't look very nice this attempts to parse the common language syntax.

`propName` PropType - Description here, oh, by the way, this prop can be `foo`, `bar`, `fee` or `fum`

It finds 20+ new enum properties which is great for `electron.d.ts`

/cc @zeke 