### PR TITLE
Ignore vendor and tests when publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.gitmodules
+.npmignore
+.travis.yml
+/test
+/vendor

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "main": "index.js",
   "repository": "https://github.com/electron/electron-docs-linter",
   "scripts": {
-    "postinstall": "npm run update-electron",
+    "prepublish": "npm run update-electron",
     "update-electron": "git submodule update --recursive --init",
     "generate": "node cli.js vendor/electron --version=1.4.1 --outfile=electron.json && open electron.json",
     "test": "mocha test/*.js && standard"


### PR DESCRIPTION
This pull request switches the submodule update to be done on `prepublish` so it happens when running `npm install` with no arguments instead of a `postinstall` so that `npm install electron-docs-linter` does not recursively clone electron.

Currently in electron/electron `node_modules` folder:

```sh
du -sh node_modules/electron-docs-linter
297M	node_modules/electron-docs-linter
```

Also adds an `.npmignore` file which shrinks the tarball generated via `npm pack .` from `58MB` to `10KB`.

/cc @zeke 