### PR TITLE
move multi-type param tests to proper file

### DIFF
--- a/test/errors.js
+++ b/test/errors.js
@@ -50,12 +50,4 @@ describe('Malformed Docs', function () {
     expect(errors[3].filename).to.equal('web-contents.md')
     expect(errors[3].html).to.equal('<code>HTMLOnly</code>')
   })
-
-  // TODO: Move this to "index.js" tests when an appropriate PR is merged into Electron
-  it('supports return types consisting of multiple types', function () {
-    var methodParam = apis.app.methods.setBadgeCount.parameters[0]
-    expect(methodParam.type).to.be.a('array')
-    expect(methodParam.type.length).to.equal(4)
-    expect(methodParam.type).to.deep.equal(['Integer', 'Number', 'Float', 'Struct'])
-  })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -200,6 +200,12 @@ describe('APIs', function () {
       expect(param.type).to.equal('String')
       expect(param.possibleValues).to.be.undefined
     })
+
+    they('support return types consisting of multiple types', function () {
+      var param = apis.ClientRequest.instanceMethods.write.parameters[0]
+      expect(param.type).to.be.an('array')
+      expect(param.type).to.deep.equal(['String', 'Buffer'])
+    })
   })
 
   describe('Static Methods', function () {


### PR DESCRIPTION
@MarshallOfSound this takes care of that TODO item, now that there are some real multi-type params documented in electron/electron.