### PR TITLE
Easier fixtures

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/electron"]
-	path = vendor/electron
-	url = https://github.com/electron/electron

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ then returns a JSON representation of all the APIs.
 
 ```js
 const lint = require('electron-docs-linter')
-const docPath = './vendor/electron/docs/api'
+const docPath = './test/fixtures/electron/docs/api'
 const targetVersion = '1.2.3' // the soon-to-be-released version of electron
 
 lint(docPath, targetVersion).then(function (apis) {

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ electron-docs-linter path/to/electron/docs
 If errors are found, they are printed to STDERR and the process
 exits un-gracefully.
 
-To lint the docs and save the generated JSON schema to a file:
+To lint the docs and save the generated [JSON schema](http://electron.atom.io/blog/2016/09/27/api-docs-json-schema) to a file:
 
 ```sh
 electron-docs-linter docs/api --version=1.2.3 --outfile=api.json

--- a/bin/fetch-docs.js
+++ b/bin/fetch-docs.js
@@ -1,0 +1,26 @@
+const electronDocs = require('electron-docs')
+const fs = require('fs')
+const path = require('path')
+const rm = require('rimraf').sync
+const mkdirp = require('mkdirp').sync
+const fixturePath = path.join(__dirname, '../test/fixtures/electron/docs/api/')
+var version = process.argv[2]
+
+console.log('removing any existing fixtures')
+rm(fixturePath)
+
+if (!version) {
+  version = 'master'
+  console.log('defaulting to master branch')
+} else {
+  console.log(`fetching docs from ${version}`)
+}
+
+electronDocs(version).then(docs => {
+  docs.forEach(doc => {
+    const filename = path.join(fixturePath, doc.filename)
+    console.log(path.relative(__dirname, filename))
+    mkdirp(path.dirname(filename))
+    fs.writeFileSync(filename, doc.markdown_content)
+  })
+})

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,29 @@
+# Contributing
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+The following is a set of guidelines for contributing to electron-docs-linter
+on GitHub. These are just guidelines, not rules, so use your best judgment
+and feel free to propose changes to this document in a pull request.
+
+## Development
+
+Install dependencies and run the tests:
+
+```sh
+npm i && npm t
+```
+
+To fetch the latest docs from electron/electron's master branch:
+
+```sh
+npm run fetch-docs
+```
+
+Sometimes it's useful to test against another branch or commit:
+
+```sh
+npm run fetch-docs -- some-other-branch
+# or
+npm run fetch-docs -- 75b010ce6314c56ec083adfa1a9835e3cfa348ea
+```

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "clean-deep": "^2.0.1",
     "decamelize": "^1.2.0",
     "dedent": "^0.6.0",
-    "electron-docs": "^1.2.3",
     "entities": "^1.1.1",
     "keyed-array": "^2.1.0",
     "lodash.pick": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "electron-docs": "^2.0.0",
-    "got": "^6.6.0",
     "mkdirp": "^0.5.1",
     "mocha": "^3.0.2",
     "rimraf": "^2.5.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "electron-docs": "^2.0.0",
+    "got": "^6.6.0",
+    "mkdirp": "^0.5.1",
     "mocha": "^3.0.2",
     "rimraf": "^2.5.4",
     "standard": "^8.0.0"
@@ -43,9 +46,8 @@
   "main": "index.js",
   "repository": "https://github.com/electron/electron-docs-linter",
   "scripts": {
-    "prepublish": "npm run update-electron",
-    "update-electron": "git submodule update --recursive --init",
-    "generate": "node cli.js vendor/electron --version=1.4.1 --outfile=electron.json && open electron.json",
+    "fetch-docs": "node bin/fetch-docs.js master",
+    "generate": "node cli.js test/fixtures/electron --version=1.4.1 --outfile=electron.json && open electron.json",
     "test": "mocha test/*.js && standard"
   },
   "standard": {

--- a/test/cli.js
+++ b/test/cli.js
@@ -10,7 +10,7 @@ describe('CLI', function () {
 
   it('produces a JSON file', function () {
     rimraf(path.join(__dirname, 'electron.json'))
-    execSync('node ' + path.join(__dirname, '../cli.js vendor/electron/docs/api --version=1.2.3 --outfile=test/electron.json'))
+    execSync('node ' + path.join(__dirname, '../cli.js test/fixtures/electron/docs/api --version=1.2.3 --outfile=test/electron.json'))
     const apis = keyedArray(require('./electron.json'))
 
     expect(apis).to.be.an('array')

--- a/test/fixtures/electron/docs/api/accelerator.md
+++ b/test/fixtures/electron/docs/api/accelerator.md
@@ -1,0 +1,71 @@
+# Accelerator
+
+> Define keyboard shortcuts.
+
+Accelerators are Strings that can contain multiple modifiers and key codes,
+combined by the `+` character, and are used to define keyboard shortcuts
+throughout your application.
+
+Examples:
+
+* `CommandOrControl+A`
+* `CommandOrControl+Shift+Z`
+
+Shortcuts are registered with the [`globalShortcut`](global-shortcut.md) module
+using the [`register`](global-shortcut.md#globalshortcutregisteraccelerator-callback)
+method, i.e.
+
+```javascript
+const {app, globalShortcut} = require('electron')
+
+app.on('ready', () => {
+  // Register a 'CommandOrControl+Y' shortcut listener.
+  globalShortcut.register('CommandOrControl+Y', () => {
+    // Do stuff when Y and either Command/Control is pressed.
+  })
+})
+```
+
+## Platform notice
+
+On Linux and Windows, the `Command` key does not have any effect so
+use `CommandOrControl` which represents `Command` on macOS and `Control` on
+Linux and Windows to define some accelerators.
+
+Use `Alt` instead of `Option`. The `Option` key only exists on macOS, whereas
+the `Alt` key is available on all platforms.
+
+The `Super` key is mapped to the `Windows` key on Windows and Linux and
+`Cmd` on macOS.
+
+## Available modifiers
+
+* `Command` (or `Cmd` for short)
+* `Control` (or `Ctrl` for short)
+* `CommandOrControl` (or `CmdOrCtrl` for short)
+* `Alt`
+* `Option`
+* `AltGr`
+* `Shift`
+* `Super`
+
+## Available key codes
+
+* `0` to `9`
+* `A` to `Z`
+* `F1` to `F24`
+* Punctuations like `~`, `!`, `@`, `#`, `$`, etc.
+* `Plus`
+* `Space`
+* `Tab`
+* `Backspace`
+* `Delete`
+* `Insert`
+* `Return` (or `Enter` as alias)
+* `Up`, `Down`, `Left` and `Right`
+* `Home` and `End`
+* `PageUp` and `PageDown`
+* `Escape` (or `Esc` for short)
+* `VolumeUp`, `VolumeDown` and `VolumeMute`
+* `MediaNextTrack`, `MediaPreviousTrack`, `MediaStop` and `MediaPlayPause`
+* `PrintScreen`

--- a/test/fixtures/electron/docs/api/app.md
+++ b/test/fixtures/electron/docs/api/app.md
@@ -519,22 +519,7 @@ The API uses the Windows Registry and LSCopyDefaultHandlerForURLScheme internall
 
 Adds `tasks` to the [Tasks][tasks] category of the JumpList on Windows.
 
-`tasks` is an array of `Task` objects in the following format:
-
-`Task` Object:
-
-* `program` String - Path of the program to execute, usually you should
-  specify `process.execPath` which opens the current program.
-* `arguments` String - The command line arguments when `program` is
-  executed.
-* `title` String - The string to be displayed in a JumpList.
-* `description` String - Description of this task.
-* `iconPath` String - The absolute path to an icon to be displayed in a
-  JumpList, which can be an arbitrary resource file that contains an icon. You
-  can usually specify `process.execPath` to show the icon of the program.
-* `iconIndex` Integer - The icon index in the icon file. If an icon file
-  consists of two or more icons, set this value to identify the icon. If an
-  icon file consists of one icon, this value is 0.
+`tasks` is an array of [`Task`](structures/task.md) objects.
 
 Returns `Boolean` - Whether the call succeeded.
 
@@ -575,23 +560,6 @@ following strings:
 If `categories` is `null` the previously set custom Jump List (if any) will be
 replaced by the standard Jump List for the app (managed by Windows).
 
-`JumpListCategory` objects should have the following properties:
-
-* `type` String - One of the following:
-  * `tasks` - Items in this category will be placed into the standard `Tasks`
-    category. There can be only one such category, and it will always be
-    displayed at the bottom of the Jump List.
-  * `frequent` - Displays a list of files frequently opened by the app, the
-    name of the category and its items are set by Windows.
-  * `recent` - Displays a list of files recently opened by the app, the name
-    of the category and its items are set by Windows. Items may be added to
-    this category indirectly using `app.addRecentDocument(path)`.
-  * `custom` - Displays tasks or file links, `name` must be set by the app.
-* `name` String - Must be set if `type` is `custom`, otherwise it should be
-  omitted.
-* `items` Array - Array of `JumpListItem` objects if `type` is `tasks` or
-  `custom`, otherwise it should be omitted.
-
 **Note:** If a `JumpListCategory` object has neither the `type` nor the `name`
 property set then its `type` is assumed to be `tasks`. If the `name` property
 is set but the `type` property is omitted then the `type` is assumed to be
@@ -603,35 +571,6 @@ the next successful call to `app.setJumpList(categories)`. Any attempt to
 re-add a removed item to a custom category earlier than that will result in the
 entire custom category being omitted from the Jump List. The list of removed
 items can be obtained using `app.getJumpListSettings()`.
-
-`JumpListItem` objects should have the following properties:
-
-* `type` String - One of the following:
-  * `task` - A task will launch an app with specific arguments.
-  * `separator` - Can be used to separate items in the standard `Tasks`
-    category.
-  * `file` - A file link will open a file using the app that created the
-    Jump List, for this to work the app must be registered as a handler for
-    the file type (though it doesn't have to be the default handler).
-* `path` String - Path of the file to open, should only be set if `type` is
-  `file`.
-* `program` String - Path of the program to execute, usually you should
-  specify `process.execPath` which opens the current program. Should only be
-  set if `type` is `task`.
-* `args` String - The command line arguments when `program` is executed. Should
-  only be set if `type` is `task`.
-* `title` String - The text to be displayed for the item in the Jump List.
-  Should only be set if `type` is `task`.
-* `description` String - Description of the task (displayed in a tooltip).
-  Should only be set if `type` is `task`.
-* `iconPath` String - The absolute path to an icon to be displayed in a
-  Jump List, which can be an arbitrary resource file that contains an icon
-  (e.g. `.ico`, `.exe`, `.dll`). You can usually specify `process.execPath` to
-  show the program icon.
-* `iconIndex` Integer - The index of the icon in the resource file. If a
-  resource file contains multiple icons this value can be used to specify the
-  zero-based index of the icon that should be displayed for this task. If a
-  resource file contains only one icon, this property should be set to zero.
 
 Here's a very simple example of creating a custom Jump List:
 
@@ -758,7 +697,7 @@ multiple instances of the application to once again run side by side.
 * `type` String - Uniquely identifies the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].
 * `userInfo` Object - App-specific state to store for use by another device.
-* `webpageURL` String - The webpage to load in a browser if no suitable app is
+* `webpageURL` String (optional) - The webpage to load in a browser if no suitable app is
   installed on the resuming device. The scheme must be `http` or `https`.
 
 Creates an `NSUserActivity` and sets it as the current activity. The activity
@@ -837,9 +776,9 @@ Returns `Object`:
 ### `app.setLoginItemSettings(settings)` _macOS_ _Windows_
 
 * `settings` Object
-  * `openAtLogin` Boolean - `true` to open the app at login, `false` to remove
+  * `openAtLogin` Boolean (optional) - `true` to open the app at login, `false` to remove
     the app as a login item. Defaults to `false`.
-  * `openAsHidden` Boolean - `true` to open the app as hidden. Defaults to
+  * `openAsHidden` Boolean (optional) - `true` to open the app as hidden. Defaults to
     `false`. The user can edit this setting from the System Preferences so
     `app.getLoginItemStatus().wasOpenedAsHidden` should be checked when the app
     is opened to know the current value. This setting is only supported on

--- a/test/fixtures/electron/docs/api/app.md
+++ b/test/fixtures/electron/docs/api/app.md
@@ -1,0 +1,964 @@
+# app
+
+> Control your application's event lifecycle.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+The following example shows how to quit the application when the last window is
+closed:
+
+```javascript
+const {app} = require('electron')
+app.on('window-all-closed', () => {
+  app.quit()
+})
+```
+
+## Events
+
+The `app` object emits the following events:
+
+### Event: 'will-finish-launching'
+
+Emitted when the application has finished basic startup. On Windows and Linux,
+the `will-finish-launching` event is the same as the `ready` event; on macOS,
+this event represents the `applicationWillFinishLaunching` notification of
+`NSApplication`. You would usually set up listeners for the `open-file` and
+`open-url` events here, and start the crash reporter and auto updater.
+
+In most cases, you should just do everything in the `ready` event handler.
+
+### Event: 'ready'
+
+Returns:
+
+* `launchInfo` Object _macOS_
+
+Emitted when Electron has finished initializing. On macOS, `launchInfo` holds
+the `userInfo` of the `NSUserNotification` that was used to open the application,
+if it was launched from Notification Center. You can call `app.isReady()` to
+check if this event has already fired.
+
+### Event: 'window-all-closed'
+
+Emitted when all windows have been closed.
+
+If you do not subscribe to this event and all windows are closed, the default
+behavior is to quit the app; however, if you subscribe, you control whether the
+app quits or not. If the user pressed `Cmd + Q`, or the developer called
+`app.quit()`, Electron will first try to close all the windows and then emit the
+`will-quit` event, and in this case the `window-all-closed` event would not be
+emitted.
+
+### Event: 'before-quit'
+
+Returns:
+
+* `event` Event
+
+Emitted before the application starts closing its windows.
+Calling `event.preventDefault()` will prevent the default behaviour, which is
+terminating the application.
+
+### Event: 'will-quit'
+
+Returns:
+
+* `event` Event
+
+Emitted when all windows have been closed and the application will quit.
+Calling `event.preventDefault()` will prevent the default behaviour, which is
+terminating the application.
+
+See the description of the `window-all-closed` event for the differences between
+the `will-quit` and `window-all-closed` events.
+
+### Event: 'quit'
+
+Returns:
+
+* `event` Event
+* `exitCode` Integer
+
+Emitted when the application is quitting.
+
+### Event: 'open-file' _macOS_
+
+Returns:
+
+* `event` Event
+* `path` String
+
+Emitted when the user wants to open a file with the application. The `open-file`
+event is usually emitted when the application is already open and the OS wants
+to reuse the application to open the file. `open-file` is also emitted when a
+file is dropped onto the dock and the application is not yet running. Make sure
+to listen for the `open-file` event very early in your application startup to
+handle this case (even before the `ready` event is emitted).
+
+You should call `event.preventDefault()` if you want to handle this event.
+
+On Windows, you have to parse `process.argv` (in the main process) to get the
+filepath.
+
+### Event: 'open-url' _macOS_
+
+Returns:
+
+* `event` Event
+* `url` String
+
+Emitted when the user wants to open a URL with the application. The URL scheme
+must be registered to be opened by your application.
+
+You should call `event.preventDefault()` if you want to handle this event.
+
+### Event: 'activate' _macOS_
+
+Returns:
+
+* `event` Event
+* `hasVisibleWindows` Boolean
+
+Emitted when the application is activated, which usually happens when the user
+clicks on the application's dock icon.
+
+### Event: 'continue-activity' _macOS_
+
+Returns:
+
+* `event` Event
+* `type` String - A string identifying the activity. Maps to
+  [`NSUserActivity.activityType`][activity-type].
+* `userInfo` Object - Contains app-specific state stored by the activity on
+  another device.
+
+Emitted during [Handoff][handoff] when an activity from a different device wants
+to be resumed. You should call `event.preventDefault()` if you want to handle
+this event.
+
+A user activity can be continued only in an app that has the same developer Team
+ID as the activity's source app and that supports the activity's type.
+Supported activity types are specified in the app's `Info.plist` under the
+`NSUserActivityTypes` key.
+
+### Event: 'browser-window-blur'
+
+Returns:
+
+* `event` Event
+* `window` BrowserWindow
+
+Emitted when a [browserWindow](browser-window.md) gets blurred.
+
+### Event: 'browser-window-focus'
+
+Returns:
+
+* `event` Event
+* `window` BrowserWindow
+
+Emitted when a [browserWindow](browser-window.md) gets focused.
+
+### Event: 'browser-window-created'
+
+Returns:
+
+* `event` Event
+* `window` BrowserWindow
+
+Emitted when a new [browserWindow](browser-window.md) is created.
+
+### Event: 'web-contents-created'
+
+Returns:
+
+* `event` Event
+* `webContents` WebContents
+
+Emitted when a new [webContents](web-contents.md) is created.
+
+### Event: 'certificate-error'
+
+Returns:
+
+* `event` Event
+* `webContents` [WebContents](web-contents.md)
+* `url` URL
+* `error` String - The error code
+* `certificate` [Certificate](structures/certificate.md)
+* `callback` Function
+  * `isTrusted` Boolean - Whether to consider the certificate as trusted
+
+Emitted when failed to verify the `certificate` for `url`, to trust the
+certificate you should prevent the default behavior with
+`event.preventDefault()` and call `callback(true)`.
+
+```javascript
+const {app} = require('electron')
+
+app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
+  if (url === 'https://github.com') {
+    // Verification logic.
+    event.preventDefault()
+    callback(true)
+  } else {
+    callback(false)
+  }
+})
+```
+
+### Event: 'select-client-certificate'
+
+Returns:
+
+* `event` Event
+* `webContents` [WebContents](web-contents.md)
+* `url` URL
+* `certificateList` [Certificate[]](structures/certificate.md)
+* `callback` Function
+  * `certificate` [Certificate](structures/certificate.md)
+
+Emitted when a client certificate is requested.
+
+The `url` corresponds to the navigation entry requesting the client certificate
+and `callback` needs to be called with an entry filtered from the list. Using
+`event.preventDefault()` prevents the application from using the first
+certificate from the store.
+
+```javascript
+const {app} = require('electron')
+
+app.on('select-client-certificate', (event, webContents, url, list, callback) => {
+  event.preventDefault()
+  callback(list[0])
+})
+```
+
+### Event: 'login'
+
+Returns:
+
+* `event` Event
+* `webContents` [WebContents](web-contents.md)
+* `request` Object
+  * `method` String
+  * `url` URL
+  * `referrer` URL
+* `authInfo` Object
+  * `isProxy` Boolean
+  * `scheme` String
+  * `host` String
+  * `port` Integer
+  * `realm` String
+* `callback` Function
+  * `username` String
+  * `password` String
+
+Emitted when `webContents` wants to do basic auth.
+
+The default behavior is to cancel all authentications, to override this you
+should prevent the default behavior with `event.preventDefault()` and call
+`callback(username, password)` with the credentials.
+
+```javascript
+const {app} = require('electron')
+
+app.on('login', (event, webContents, request, authInfo, callback) => {
+  event.preventDefault()
+  callback('username', 'secret')
+})
+```
+
+### Event: 'gpu-process-crashed'
+
+Returns:
+
+* `event` Event
+* `killed` Boolean
+
+Emitted when the gpu process crashes or is killed.
+
+### Event: 'accessibility-support-changed' _macOS_ _Windows_
+
+Returns:
+
+* `event` Event
+* `accessibilitySupportEnabled` Boolean - `true` when Chrome's accessibility
+  support is enabled, `false` otherwise.
+
+Emitted when Chrome's accessibility support changes. This event fires when
+assistive technologies, such as screen readers, are enabled or disabled.
+See https://www.chromium.org/developers/design-documents/accessibility for more
+details.
+
+## Methods
+
+The `app` object has the following methods:
+
+**Note:** Some methods are only available on specific operating systems and are
+labeled as such.
+
+### `app.quit()`
+
+Try to close all windows. The `before-quit` event will be emitted first. If all
+windows are successfully closed, the `will-quit` event will be emitted and by
+default the application will terminate.
+
+This method guarantees that all `beforeunload` and `unload` event handlers are
+correctly executed. It is possible that a window cancels the quitting by
+returning `false` in the `beforeunload` event handler.
+
+### `app.exit([exitCode])`
+
+* `exitCode` Integer (optional)
+
+Exits immediately with `exitCode`.  `exitCode` defaults to 0.
+
+All windows will be closed immediately without asking user and the `before-quit`
+and `will-quit` events will not be emitted.
+
+### `app.relaunch([options])`
+
+* `options` Object (optional)
+  * `args` String[] (optional)
+  * `execPath` String (optional)
+
+Relaunches the app when current instance exits.
+
+By default the new instance will use the same working directory and command line
+arguments with current instance. When `args` is specified, the `args` will be
+passed as command line arguments instead. When `execPath` is specified, the
+`execPath` will be executed for relaunch instead of current app.
+
+Note that this method does not quit the app when executed, you have to call
+`app.quit` or `app.exit` after calling `app.relaunch` to make the app restart.
+
+When `app.relaunch` is called for multiple times, multiple instances will be
+started after current instance exited.
+
+An example of restarting current instance immediately and adding a new command
+line argument to the new instance:
+
+```javascript
+const {app} = require('electron')
+
+app.relaunch({args: process.argv.slice(1).concat(['--relaunch'])})
+app.exit(0)
+```
+
+### `app.isReady()`
+
+Returns `Boolean` - `true` if Electron has finished initializing, `false` otherwise.
+
+### `app.focus()`
+
+On Linux, focuses on the first visible window. On macOS, makes the application
+the active app. On Windows, focuses on the application's first window.
+
+### `app.hide()` _macOS_
+
+Hides all application windows without minimizing them.
+
+### `app.show()` _macOS_
+
+Shows application windows after they were hidden. Does not automatically focus
+them.
+
+### `app.getAppPath()`
+
+Returns `String` - The current application directory.
+
+### `app.getPath(name)`
+
+* `name` String
+
+Returns `String` - A path to a special directory or file associated with `name`. On
+failure an `Error` is thrown.
+
+You can request the following paths by the name:
+
+* `home` User's home directory.
+* `appData` Per-user application data directory, which by default points to:
+  * `%APPDATA%` on Windows
+  * `$XDG_CONFIG_HOME` or `~/.config` on Linux
+  * `~/Library/Application Support` on macOS
+* `userData` The directory for storing your app's configuration files, which by
+  default it is the `appData` directory appended with your app's name.
+* `temp` Temporary directory.
+* `exe` The current executable file.
+* `module` The `libchromiumcontent` library.
+* `desktop` The current user's Desktop directory.
+* `documents` Directory for a user's "My Documents".
+* `downloads` Directory for a user's downloads.
+* `music` Directory for a user's music.
+* `pictures` Directory for a user's pictures.
+* `videos` Directory for a user's videos.
+* `pepperFlashSystemPlugin`  Full path to the system version of the Pepper Flash plugin.
+
+### `app.setPath(name, path)`
+
+* `name` String
+* `path` String
+
+Overrides the `path` to a special directory or file associated with `name`. If
+the path specifies a directory that does not exist, the directory will be
+created by this method. On failure an `Error` is thrown.
+
+You can only override paths of a `name` defined in `app.getPath`.
+
+By default, web pages' cookies and caches will be stored under the `userData`
+directory. If you want to change this location, you have to override the
+`userData` path before the `ready` event of the `app` module is emitted.
+
+### `app.getVersion()`
+
+Returns `String` - The version of the loaded application. If no version is found in the
+application's `package.json` file, the version of the current bundle or
+executable is returned.
+
+### `app.getName()`
+
+Returns `String` - The current application's name, which is the name in the application's
+`package.json` file.
+
+Usually the `name` field of `package.json` is a short lowercased name, according
+to the npm modules spec. You should usually also specify a `productName`
+field, which is your application's full capitalized name, and which will be
+preferred over `name` by Electron.
+
+### `app.setName(name)`
+
+* `name` String
+
+Overrides the current application's name.
+
+### `app.getLocale()`
+
+Returns `String` - The current application locale. Possible return values are documented
+[here](locales.md).
+
+**Note:** When distributing your packaged app, you have to also ship the
+`locales` folder.
+
+**Note:** On Windows you have to call it after the `ready` events gets emitted.
+
+### `app.addRecentDocument(path)` _macOS_ _Windows_
+
+* `path` String
+
+Adds `path` to the recent documents list.
+
+This list is managed by the OS. On Windows you can visit the list from the task
+bar, and on macOS you can visit it from dock menu.
+
+### `app.clearRecentDocuments()` _macOS_ _Windows_
+
+Clears the recent documents list.
+
+### `app.setAsDefaultProtocolClient(protocol[, path, args])` _macOS_ _Windows_
+
+* `protocol` String - The name of your protocol, without `://`. If you want your
+  app to handle `electron://` links, call this method with `electron` as the
+  parameter.
+* `path` String (optional) _Windows_ - Defaults to `process.execPath`
+* `args` String[] (optional) _Windows_ - Defaults to an empty array
+
+Returns `Boolean` - Whether the call succeeded.
+
+This method sets the current executable as the default handler for a protocol
+(aka URI scheme). It allows you to integrate your app deeper into the operating
+system. Once registered, all links with `your-protocol://` will be opened with
+the current executable. The whole link, including protocol, will be passed to
+your application as a parameter.
+
+On Windows you can provide optional parameters path, the path to your executable,
+and args, an array of arguments to be passed to your executable when it launches.
+
+**Note:** On macOS, you can only register protocols that have been added to
+your app's `info.plist`, which can not be modified at runtime. You can however
+change the file with a simple text editor or script during build time.
+Please refer to [Apple's documentation][CFBundleURLTypes] for details.
+
+The API uses the Windows Registry and LSSetDefaultHandlerForURLScheme internally.
+
+### `app.removeAsDefaultProtocolClient(protocol[, path, args])` _macOS_ _Windows_
+
+* `protocol` String - The name of your protocol, without `://`.
+* `path` String (optional) _Windows_ - Defaults to `process.execPath`
+* `args` String[] (optional) _Windows_ - Defaults to an empty array
+
+Returns `Boolean` - Whether the call succeeded.
+
+This method checks if the current executable as the default handler for a
+protocol (aka URI scheme). If so, it will remove the app as the default handler.
+
+
+### `app.isDefaultProtocolClient(protocol[, path, args])` _macOS_ _Windows_
+
+* `protocol` String - The name of your protocol, without `://`.
+* `path` String (optional) _Windows_ - Defaults to `process.execPath`
+* `args` String[] (optional) _Windows_ - Defaults to an empty array
+
+Returns `Boolean`
+
+This method checks if the current executable is the default handler for a protocol
+(aka URI scheme). If so, it will return true. Otherwise, it will return false.
+
+**Note:** On macOS, you can use this method to check if the app has been
+registered as the default protocol handler for a protocol. You can also verify
+this by checking `~/Library/Preferences/com.apple.LaunchServices.plist` on the
+macOS machine. Please refer to
+[Apple's documentation][LSCopyDefaultHandlerForURLScheme] for details.
+
+The API uses the Windows Registry and LSCopyDefaultHandlerForURLScheme internally.
+
+### `app.setUserTasks(tasks)` _Windows_
+
+* `tasks` [Task[]](structures/task.md) - Array of `Task` objects
+
+Adds `tasks` to the [Tasks][tasks] category of the JumpList on Windows.
+
+`tasks` is an array of `Task` objects in the following format:
+
+`Task` Object:
+
+* `program` String - Path of the program to execute, usually you should
+  specify `process.execPath` which opens the current program.
+* `arguments` String - The command line arguments when `program` is
+  executed.
+* `title` String - The string to be displayed in a JumpList.
+* `description` String - Description of this task.
+* `iconPath` String - The absolute path to an icon to be displayed in a
+  JumpList, which can be an arbitrary resource file that contains an icon. You
+  can usually specify `process.execPath` to show the icon of the program.
+* `iconIndex` Integer - The icon index in the icon file. If an icon file
+  consists of two or more icons, set this value to identify the icon. If an
+  icon file consists of one icon, this value is 0.
+
+Returns `Boolean` - Whether the call succeeded.
+
+**Note:** If you'd like to customize the Jump List even more use
+`app.setJumpList(categories)` instead.
+
+### `app.getJumpListSettings()` _Windows_
+
+Returns `Object`:
+
+* `minItems` Integer - The minimum number of items that will be shown in the
+  Jump List (for a more detailed description of this value see the
+  [MSDN docs][JumpListBeginListMSDN]).
+* `removedItems` [JumpListItem[]](structures/jump-list-item.md) - Array of `JumpListItem` objects that correspond to
+  items that the user has explicitly removed from custom categories in the
+  Jump List. These items must not be re-added to the Jump List in the **next**
+  call to `app.setJumpList()`, Windows will not display any custom category
+  that contains any of the removed items.
+
+### `app.setJumpList(categories)` _Windows_
+
+* `categories` [JumpListCategory[]](structures/jump-list-category.md) or `null` - Array of `JumpListCategory` objects.
+
+Sets or removes a custom Jump List for the application, and returns one of the
+following strings:
+
+* `ok` - Nothing went wrong.
+* `error` - One or more errors occurred, enable runtime logging to figure out
+  the likely cause.
+* `invalidSeparatorError` - An attempt was made to add a separator to a
+  custom category in the Jump List. Separators are only allowed in the
+  standard `Tasks` category.
+* `fileTypeRegistrationError` - An attempt was made to add a file link to
+  the Jump List for a file type the app isn't registered to handle.
+* `customCategoryAccessDeniedError` - Custom categories can't be added to the
+  Jump List due to user privacy or group policy settings.
+
+If `categories` is `null` the previously set custom Jump List (if any) will be
+replaced by the standard Jump List for the app (managed by Windows).
+
+`JumpListCategory` objects should have the following properties:
+
+* `type` String - One of the following:
+  * `tasks` - Items in this category will be placed into the standard `Tasks`
+    category. There can be only one such category, and it will always be
+    displayed at the bottom of the Jump List.
+  * `frequent` - Displays a list of files frequently opened by the app, the
+    name of the category and its items are set by Windows.
+  * `recent` - Displays a list of files recently opened by the app, the name
+    of the category and its items are set by Windows. Items may be added to
+    this category indirectly using `app.addRecentDocument(path)`.
+  * `custom` - Displays tasks or file links, `name` must be set by the app.
+* `name` String - Must be set if `type` is `custom`, otherwise it should be
+  omitted.
+* `items` Array - Array of `JumpListItem` objects if `type` is `tasks` or
+  `custom`, otherwise it should be omitted.
+
+**Note:** If a `JumpListCategory` object has neither the `type` nor the `name`
+property set then its `type` is assumed to be `tasks`. If the `name` property
+is set but the `type` property is omitted then the `type` is assumed to be
+`custom`.
+
+**Note:** Users can remove items from custom categories, and Windows will not
+allow a removed item to be added back into a custom category until **after**
+the next successful call to `app.setJumpList(categories)`. Any attempt to
+re-add a removed item to a custom category earlier than that will result in the
+entire custom category being omitted from the Jump List. The list of removed
+items can be obtained using `app.getJumpListSettings()`.
+
+`JumpListItem` objects should have the following properties:
+
+* `type` String - One of the following:
+  * `task` - A task will launch an app with specific arguments.
+  * `separator` - Can be used to separate items in the standard `Tasks`
+    category.
+  * `file` - A file link will open a file using the app that created the
+    Jump List, for this to work the app must be registered as a handler for
+    the file type (though it doesn't have to be the default handler).
+* `path` String - Path of the file to open, should only be set if `type` is
+  `file`.
+* `program` String - Path of the program to execute, usually you should
+  specify `process.execPath` which opens the current program. Should only be
+  set if `type` is `task`.
+* `args` String - The command line arguments when `program` is executed. Should
+  only be set if `type` is `task`.
+* `title` String - The text to be displayed for the item in the Jump List.
+  Should only be set if `type` is `task`.
+* `description` String - Description of the task (displayed in a tooltip).
+  Should only be set if `type` is `task`.
+* `iconPath` String - The absolute path to an icon to be displayed in a
+  Jump List, which can be an arbitrary resource file that contains an icon
+  (e.g. `.ico`, `.exe`, `.dll`). You can usually specify `process.execPath` to
+  show the program icon.
+* `iconIndex` Integer - The index of the icon in the resource file. If a
+  resource file contains multiple icons this value can be used to specify the
+  zero-based index of the icon that should be displayed for this task. If a
+  resource file contains only one icon, this property should be set to zero.
+
+Here's a very simple example of creating a custom Jump List:
+
+```javascript
+const {app} = require('electron')
+
+app.setJumpList([
+  {
+    type: 'custom',
+    name: 'Recent Projects',
+    items: [
+      { type: 'file', path: 'C:\\Projects\\project1.proj' },
+      { type: 'file', path: 'C:\\Projects\\project2.proj' }
+    ]
+  },
+  { // has a name so `type` is assumed to be "custom"
+    name: 'Tools',
+    items: [
+      {
+        type: 'task',
+        title: 'Tool A',
+        program: process.execPath,
+        args: '--run-tool-a',
+        icon: process.execPath,
+        iconIndex: 0,
+        description: 'Runs Tool A'
+      },
+      {
+        type: 'task',
+        title: 'Tool B',
+        program: process.execPath,
+        args: '--run-tool-b',
+        icon: process.execPath,
+        iconIndex: 0,
+        description: 'Runs Tool B'
+      }
+    ]
+  },
+  { type: 'frequent' },
+  { // has no name and no type so `type` is assumed to be "tasks"
+    items: [
+      {
+        type: 'task',
+        title: 'New Project',
+        program: process.execPath,
+        args: '--new-project',
+        description: 'Create a new project.'
+      },
+      { type: 'separator' },
+      {
+        type: 'task',
+        title: 'Recover Project',
+        program: process.execPath,
+        args: '--recover-project',
+        description: 'Recover Project'
+      }
+    ]
+  }
+])
+```
+
+### `app.makeSingleInstance(callback)`
+
+* `callback` Function
+  * `argv` String[] - An array of the second instance's command line arguments
+  * `workingDirectory` String - The second instance's working directory
+
+This method makes your application a Single Instance Application - instead of
+allowing multiple instances of your app to run, this will ensure that only a
+single instance of your app is running, and other instances signal this
+instance and exit.
+
+`callback` will be called with `callback(argv, workingDirectory)` when a second
+instance has been executed. `argv` is an Array of the second instance's command
+line arguments, and `workingDirectory` is its current working directory. Usually
+applications respond to this by making their primary window focused and
+non-minimized.
+
+The `callback` is guaranteed to be executed after the `ready` event of `app`
+gets emitted.
+
+This method returns `false` if your process is the primary instance of the
+application and your app should continue loading. And returns `true` if your
+process has sent its parameters to another instance, and you should immediately
+quit.
+
+On macOS the system enforces single instance automatically when users try to open
+a second instance of your app in Finder, and the `open-file` and `open-url`
+events will be emitted for that. However when users start your app in command
+line the system's single instance mechanism will be bypassed and you have to
+use this method to ensure single instance.
+
+An example of activating the window of primary instance when a second instance
+starts:
+
+```javascript
+const {app} = require('electron')
+let myWindow = null
+
+const shouldQuit = app.makeSingleInstance((commandLine, workingDirectory) => {
+  // Someone tried to run a second instance, we should focus our window.
+  if (myWindow) {
+    if (myWindow.isMinimized()) myWindow.restore()
+    myWindow.focus()
+  }
+})
+
+if (shouldQuit) {
+  app.quit()
+}
+
+// Create myWindow, load the rest of the app, etc...
+app.on('ready', () => {
+})
+```
+
+### `app.releaseSingleInstance()`
+
+Releases all locks that were created by `makeSingleInstance`. This will allow
+multiple instances of the application to once again run side by side.
+
+### `app.setUserActivity(type, userInfo[, webpageURL])` _macOS_
+
+* `type` String - Uniquely identifies the activity. Maps to
+  [`NSUserActivity.activityType`][activity-type].
+* `userInfo` Object - App-specific state to store for use by another device.
+* `webpageURL` String - The webpage to load in a browser if no suitable app is
+  installed on the resuming device. The scheme must be `http` or `https`.
+
+Creates an `NSUserActivity` and sets it as the current activity. The activity
+is eligible for [Handoff][handoff] to another device afterward.
+
+### `app.getCurrentActivityType()` _macOS_
+
+Returns `String` - The type of the currently running activity.
+
+### `app.setAppUserModelId(id)` _Windows_
+
+* `id` String
+
+Changes the [Application User Model ID][app-user-model-id] to `id`.
+
+### `app.importCertificate(options, callback)` _LINUX_
+
+* `options` Object
+  * `certificate` String - Path for the pkcs12 file.
+  * `password` String - Passphrase for the certificate.
+* `callback` Function
+  * `result` Integer - Result of import.
+
+Imports the certificate in pkcs12 format into the platform certificate store.
+`callback` is called with the `result` of import operation, a value of `0`
+indicates success while any other value indicates failure according to chromium [net_error_list](https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h).
+
+### `app.disableHardwareAcceleration()`
+
+Disables hardware acceleration for current app.
+
+This method can only be called before app is ready.
+
+### `app.setBadgeCount(count)` _Linux_ _macOS_
+
+* `count` Integer
+
+Returns `Boolean` - Whether the call succeeded.
+
+Sets the counter badge for current app. Setting the count to `0` will hide the
+badge.
+
+On macOS it shows on the dock icon. On Linux it only works for Unity launcher,
+
+**Note:** Unity launcher requires the exsistence of a `.desktop` file to work,
+for more information please read [Desktop Environment Integration][unity-requiremnt].
+
+### `app.getBadgeCount()` _Linux_ _macOS_
+
+Returns `Integer` - The current value displayed in the counter badge.
+
+### `app.isUnityRunning()` _Linux_
+
+Returns `Boolean` - Whether the current desktop environment is Unity launcher.
+
+### `app.getLoginItemSettings()` _macOS_ _Windows_
+
+Returns `Object`:
+
+* `openAtLogin` Boolean - `true` if the app is set to open at login.
+* `openAsHidden` Boolean - `true` if the app is set to open as hidden at login.
+  This setting is only supported on macOS.
+* `wasOpenedAtLogin` Boolean - `true` if the app was opened at login
+  automatically. This setting is only supported on macOS.
+* `wasOpenedAsHidden` Boolean - `true` if the app was opened as a hidden login
+  item. This indicates that the app should not open any windows at startup.
+  This setting is only supported on macOS.
+* `restoreState` Boolean - `true` if the app was opened as a login item that
+  should restore the state from the previous session. This indicates that the
+  app should restore the windows that were open the last time the app was
+  closed. This setting is only supported on macOS.
+
+**Note:** This API has no effect on
+[MAS builds][mas-builds].
+
+### `app.setLoginItemSettings(settings)` _macOS_ _Windows_
+
+* `settings` Object
+  * `openAtLogin` Boolean - `true` to open the app at login, `false` to remove
+    the app as a login item. Defaults to `false`.
+  * `openAsHidden` Boolean - `true` to open the app as hidden. Defaults to
+    `false`. The user can edit this setting from the System Preferences so
+    `app.getLoginItemStatus().wasOpenedAsHidden` should be checked when the app
+    is opened to know the current value. This setting is only supported on
+    macOS.
+
+Set the app's login item settings.
+
+**Note:** This API has no effect on
+[MAS builds][mas-builds].
+
+### `app.isAccessibilitySupportEnabled()` _macOS_ _Windows_
+
+Returns `Boolean` - `true` if Chrome's accessibility support is enabled,
+`false` otherwise. This API will return `true` if the use of assistive
+technologies, such as screen readers, has been detected. See
+https://www.chromium.org/developers/design-documents/accessibility for more
+details.
+
+### `app.setAboutPanelOptions(options)` _macOS_
+
+* `options` Object
+  * `applicationName` String (optional) - The app's name.
+  * `applicationVersion` String (optional) - The app's version.
+  * `copyright` String (optional) - Copyright information.
+  * `credits` String (optional) - Credit information.
+  * `version` String (optional) - The app's build version number.
+
+Set the about panel options. This will override the values defined in the app's
+`.plist` file. See the [Apple docs][about-panel-options] for more details.
+
+### `app.commandLine.appendSwitch(switch[, value])`
+
+* `switch` String - A command-line switch
+* `value` String (optional) - A value for the given switch
+
+Append a switch (with optional `value`) to Chromium's command line.
+
+**Note:** This will not affect `process.argv`, and is mainly used by developers
+to control some low-level Chromium behaviors.
+
+### `app.commandLine.appendArgument(value)`
+
+* `value` String - The argument to append to the command line
+
+Append an argument to Chromium's command line. The argument will be quoted
+correctly.
+
+**Note:** This will not affect `process.argv`.
+
+### `app.dock.bounce([type])` _macOS_
+
+* `type` String (optional) - Can be `critical` or `informational`. The default is
+ `informational`
+
+When `critical` is passed, the dock icon will bounce until either the
+application becomes active or the request is canceled.
+
+When `informational` is passed, the dock icon will bounce for one second.
+However, the request remains active until either the application becomes active
+or the request is canceled.
+
+Returns an ID representing the request.
+
+### `app.dock.cancelBounce(id)` _macOS_
+
+* `id` Integer
+
+Cancel the bounce of `id`.
+
+### `app.dock.downloadFinished(filePath)` _macOS_
+
+* `filePath` String
+
+Bounces the Downloads stack if the filePath is inside the Downloads folder.
+
+### `app.dock.setBadge(text)` _macOS_
+
+* `text` String
+
+Sets the string to be displayed in the dock’s badging area.
+
+### `app.dock.getBadge()` _macOS_
+
+Returns `String` - The badge string of the dock.
+
+### `app.dock.hide()` _macOS_
+
+Hides the dock icon.
+
+### `app.dock.show()` _macOS_
+
+Shows the dock icon.
+
+### `app.dock.isVisible()` _macOS_
+
+Returns `Boolean` - Whether the dock icon is visible.
+The `app.dock.show()` call is asynchronous so this method might not
+return true immediately after that call.
+
+### `app.dock.setMenu(menu)` _macOS_
+
+* `menu` [Menu](menu.md)
+
+Sets the application's [dock menu][dock-menu].
+
+### `app.dock.setIcon(image)` _macOS_
+
+* `image` [NativeImage](native-image.md)
+
+Sets the `image` associated with this dock icon.
+
+[dock-menu]:https://developer.apple.com/library/mac/documentation/Carbon/Conceptual/customizing_docktile/concepts/dockconcepts.html#//apple_ref/doc/uid/TP30000986-CH2-TPXREF103
+[tasks]:http://msdn.microsoft.com/en-us/library/windows/desktop/dd378460(v=vs.85).aspx#tasks
+[app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
+[CFBundleURLTypes]: https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-102207-TPXREF115
+[LSCopyDefaultHandlerForURLScheme]: https://developer.apple.com/library/mac/documentation/Carbon/Reference/LaunchServicesReference/#//apple_ref/c/func/LSCopyDefaultHandlerForURLScheme
+[handoff]: https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/Handoff/HandoffFundamentals/HandoffFundamentals.html
+[activity-type]: https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSUserActivity_Class/index.html#//apple_ref/occ/instp/NSUserActivity/activityType
+[unity-requiremnt]: ../tutorial/desktop-environment-integration.md#unity-launcher-shortcuts-linux
+[mas-builds]: ../tutorial/mac-app-store-submission-guide.md
+[JumpListBeginListMSDN]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378398(v=vs.85).aspx
+[about-panel-options]: https://developer.apple.com/reference/appkit/nsapplication/1428479-orderfrontstandardaboutpanelwith?language=objc

--- a/test/fixtures/electron/docs/api/auto-updater.md
+++ b/test/fixtures/electron/docs/api/auto-updater.md
@@ -1,0 +1,130 @@
+# autoUpdater
+
+> Enable apps to automatically update themselves.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+The `autoUpdater` module provides an interface for the
+[Squirrel](https://github.com/Squirrel) framework.
+
+You can quickly launch a multi-platform release server for distributing your
+application by using one of these projects:
+
+- [nuts][nuts]: *A smart release server for your applications, using GitHub as a backend. Auto-updates with Squirrel (Mac & Windows)*
+- [electron-release-server][electron-release-server]: *A fully featured,
+  self-hosted release server for electron applications, compatible with
+  auto-updater*
+- [squirrel-updates-server][squirrel-updates-server]: *A simple node.js server
+  for Squirrel.Mac and Squirrel.Windows which uses GitHub releases*
+
+## Platform notices
+
+Though `autoUpdater` provides a uniform API for different platforms, there are
+still some subtle differences on each platform.
+
+### macOS
+
+On macOS, the `autoUpdater` module is built upon [Squirrel.Mac][squirrel-mac],
+meaning you don't need any special setup to make it work. For server-side
+requirements, you can read [Server Support][server-support].
+
+**Note:** Your application must be signed for automatic updates on macOS.
+This is a requirement of `Squirrel.Mac`.
+
+### Windows
+
+On Windows, you have to install your app into a user's machine before you can
+use the `autoUpdater`, so it is recommended that you use the
+[electron-winstaller][installer-lib], [electron-builder][electron-builder-lib] or the [grunt-electron-installer][installer] package to generate a Windows installer.
+
+When using [electron-winstaller][installer-lib] or [electron-builder][electron-builder-lib] make sure you do not try to update your app [the first time it runs](https://github.com/electron/windows-installer#handling-squirrel-events) (Also see [this issue for more info](https://github.com/electron/electron/issues/7155)). It's also recommended to use [electron-squirrel-startup](electron-squirrel-startup) to get desktop shortcuts for your app.
+
+The installer generated with Squirrel will create a shortcut icon with an
+[Application User Model ID][app-user-model-id] in the format of
+`com.squirrel.PACKAGE_ID.YOUR_EXE_WITHOUT_DOT_EXE`, examples are
+`com.squirrel.slack.Slack` and `com.squirrel.code.Code`. You have to use the
+same ID for your app with `app.setAppUserModelId` API, otherwise Windows will
+not be able to pin your app properly in task bar.
+
+The server-side setup is also different from macOS. You can read the documents of
+[Squirrel.Windows][squirrel-windows] to get more details.
+
+### Linux
+
+There is no built-in support for auto-updater on Linux, so it is recommended to
+use the distribution's package manager to update your app.
+
+## Events
+
+The `autoUpdater` object emits the following events:
+
+### Event: 'error'
+
+Returns:
+
+* `error` Error
+
+Emitted when there is an error while updating.
+
+### Event: 'checking-for-update'
+
+Emitted when checking if an update has started.
+
+### Event: 'update-available'
+
+Emitted when there is an available update. The update is downloaded
+automatically.
+
+### Event: 'update-not-available'
+
+Emitted when there is no available update.
+
+### Event: 'update-downloaded'
+
+Returns:
+
+* `event` Event
+* `releaseNotes` String
+* `releaseName` String
+* `releaseDate` Date
+* `updateURL` String
+
+Emitted when an update has been downloaded.
+
+On Windows only `releaseName` is available.
+
+## Methods
+
+The `autoUpdater` object has the following methods:
+
+### `autoUpdater.setFeedURL(url[, requestHeaders])`
+
+* `url` String
+* `requestHeaders` Object _macOS_ - HTTP request headers.
+
+Sets the `url` and initialize the auto updater.
+
+### `autoUpdater.getFeedURL()`
+
+Returns `String` - The current update feed URL.
+
+### `autoUpdater.checkForUpdates()`
+
+Asks the server whether there is an update. You must call `setFeedURL` before
+using this API.
+
+### `autoUpdater.quitAndInstall()`
+
+Restarts the app and installs the update after it has been downloaded. It
+should only be called after `update-downloaded` has been emitted.
+
+[squirrel-mac]: https://github.com/Squirrel/Squirrel.Mac
+[server-support]: https://github.com/Squirrel/Squirrel.Mac#server-support
+[squirrel-windows]: https://github.com/Squirrel/Squirrel.Windows
+[installer]: https://github.com/electron/grunt-electron-installer
+[installer-lib]: https://github.com/electron/windows-installer
+[electron-builder-lib]: https://github.com/electron-userland/electron-builder
+[app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
+[electron-release-server]: https://github.com/ArekSredzki/electron-release-server
+[squirrel-updates-server]: https://github.com/Aluxian/squirrel-updates-server
+[nuts]: https://github.com/GitbookIO/nuts

--- a/test/fixtures/electron/docs/api/auto-updater.md
+++ b/test/fixtures/electron/docs/api/auto-updater.md
@@ -100,7 +100,7 @@ The `autoUpdater` object has the following methods:
 ### `autoUpdater.setFeedURL(url[, requestHeaders])`
 
 * `url` String
-* `requestHeaders` Object _macOS_ - HTTP request headers.
+* `requestHeaders` Object _macOS_ (optional) - HTTP request headers.
 
 Sets the `url` and initialize the auto updater.
 

--- a/test/fixtures/electron/docs/api/browser-window.md
+++ b/test/fixtures/electron/docs/api/browser-window.md
@@ -116,78 +116,78 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
 
 ### `new BrowserWindow([options])`
 
-* `options` Object
-  * `width` Integer - Window's width in pixels. Default is `800`.
-  * `height` Integer - Window's height in pixels. Default is `600`.
-  * `x` Integer (**required** if y is used) - Window's left offset from screen.
+* `options` Object (optional)
+  * `width` Integer (optional) - Window's width in pixels. Default is `800`.
+  * `height` Integer (optional) - Window's height in pixels. Default is `600`.
+  * `x` Integer (optional) (**required** if y is used) - Window's left offset from screen.
     Default is to center the window.
-  * `y` Integer (**required** if x is used) - Window's top offset from screen.
+  * `y` Integer (optional) (**required** if x is used) - Window's top offset from screen.
     Default is to center the window.
-  * `useContentSize` Boolean - The `width` and `height` would be used as web
+  * `useContentSize` Boolean (optional) - The `width` and `height` would be used as web
     page's size, which means the actual window's size will include window
     frame's size and be slightly larger. Default is `false`.
-  * `center` Boolean - Show window in the center of the screen.
-  * `minWidth` Integer - Window's minimum width. Default is `0`.
-  * `minHeight` Integer - Window's minimum height. Default is `0`.
-  * `maxWidth` Integer - Window's maximum width. Default is no limit.
-  * `maxHeight` Integer - Window's maximum height. Default is no limit.
-  * `resizable` Boolean - Whether window is resizable. Default is `true`.
-  * `movable` Boolean - Whether window is movable. This is not implemented
+  * `center` Boolean (optional) - Show window in the center of the screen.
+  * `minWidth` Integer (optional) - Window's minimum width. Default is `0`.
+  * `minHeight` Integer (optional) - Window's minimum height. Default is `0`.
+  * `maxWidth` Integer (optional) - Window's maximum width. Default is no limit.
+  * `maxHeight` Integer (optional) - Window's maximum height. Default is no limit.
+  * `resizable` Boolean (optional) - Whether window is resizable. Default is `true`.
+  * `movable` Boolean (optional) - Whether window is movable. This is not implemented
     on Linux. Default is `true`.
-  * `minimizable` Boolean - Whether window is minimizable. This is not
+  * `minimizable` Boolean (optional) - Whether window is minimizable. This is not
     implemented on Linux. Default is `true`.
-  * `maximizable` Boolean - Whether window is maximizable. This is not
+  * `maximizable` Boolean (optional) - Whether window is maximizable. This is not
     implemented on Linux. Default is `true`.
-  * `closable` Boolean - Whether window is closable. This is not implemented
+  * `closable` Boolean (optional) - Whether window is closable. This is not implemented
     on Linux. Default is `true`.
-  * `focusable` Boolean - Whether the window can be focused. Default is
+  * `focusable` Boolean (optional) - Whether the window can be focused. Default is
     `true`. On Windows setting `focusable: false` also implies setting
     `skipTaskbar: true`. On Linux setting `focusable: false` makes the window
     stop interacting with wm, so the window will always stay on top in all
     workspaces.
-  * `alwaysOnTop` Boolean - Whether the window should always stay on top of
+  * `alwaysOnTop` Boolean (optional) - Whether the window should always stay on top of
     other windows. Default is `false`.
-  * `fullscreen` Boolean - Whether the window should show in fullscreen. When
+  * `fullscreen` Boolean (optional) - Whether the window should show in fullscreen. When
     explicitly set to `false` the fullscreen button will be hidden or disabled
     on macOS. Default is `false`.
-  * `fullscreenable` Boolean - Whether the window can be put into fullscreen
+  * `fullscreenable` Boolean (optional) - Whether the window can be put into fullscreen
     mode. On macOS, also whether the maximize/zoom button should toggle full
     screen mode or maximize window. Default is `true`.
-  * `skipTaskbar` Boolean - Whether to show the window in taskbar. Default is
+  * `skipTaskbar` Boolean (optional) - Whether to show the window in taskbar. Default is
     `false`.
-  * `kiosk` Boolean - The kiosk mode. Default is `false`.
-  * `title` String - Default window title. Default is `"Electron"`.
-  * `icon` [NativeImage](native-image.md) - The window icon. On Windows it is
+  * `kiosk` Boolean (optional) - The kiosk mode. Default is `false`.
+  * `title` String (optional) - Default window title. Default is `"Electron"`.
+  * `icon` ([NativeImage](native-image.md) | String) (optional) - The window icon. On Windows it is
     recommended to use `ICO` icons to get best visual effects, you can also
     leave it undefined so the executable's icon will be used.
-  * `show` Boolean - Whether window should be shown when created. Default is
+  * `show` Boolean (optional) - Whether window should be shown when created. Default is
     `true`.
-  * `frame` Boolean - Specify `false` to create a
+  * `frame` Boolean (optional) - Specify `false` to create a
     [Frameless Window](frameless-window.md). Default is `true`.
-  * `parent` BrowserWindow - Specify parent window. Default is `null`.
-  * `modal` Boolean - Whether this is a modal window. This only works when the
+  * `parent` BrowserWindow (optional) - Specify parent window. Default is `null`.
+  * `modal` Boolean (optional) - Whether this is a modal window. This only works when the
     window is a child window. Default is `false`.
-  * `acceptFirstMouse` Boolean - Whether the web view accepts a single
+  * `acceptFirstMouse` Boolean (optional) - Whether the web view accepts a single
     mouse-down event that simultaneously activates the window. Default is
     `false`.
-  * `disableAutoHideCursor` Boolean - Whether to hide cursor when typing.
+  * `disableAutoHideCursor` Boolean (optional) - Whether to hide cursor when typing.
     Default is `false`.
-  * `autoHideMenuBar` Boolean - Auto hide the menu bar unless the `Alt`
+  * `autoHideMenuBar` Boolean (optional) - Auto hide the menu bar unless the `Alt`
     key is pressed. Default is `false`.
-  * `enableLargerThanScreen` Boolean - Enable the window to be resized larger
+  * `enableLargerThanScreen` Boolean (optional) - Enable the window to be resized larger
     than screen. Default is `false`.
-  * `backgroundColor` String - Window's background color as Hexadecimal value,
+  * `backgroundColor` String (optional) - Window's background color as Hexadecimal value,
     like `#66CD00` or `#FFF` or `#80FFFFFF` (alpha is supported). Default is
     `#FFF` (white).
-  * `hasShadow` Boolean - Whether window should have a shadow. This is only
+  * `hasShadow` Boolean (optional) - Whether window should have a shadow. This is only
     implemented on macOS. Default is `true`.
-  * `darkTheme` Boolean - Forces using dark theme for the window, only works on
+  * `darkTheme` Boolean (optional) - Forces using dark theme for the window, only works on
     some GTK+3 desktop environments. Default is `false`.
-  * `transparent` Boolean - Makes the window [transparent](frameless-window.md).
+  * `transparent` Boolean (optional) - Makes the window [transparent](frameless-window.md).
     Default is `false`.
-  * `type` String - The type of window, default is normal window. See more about
+  * `type` String (optional) - The type of window, default is normal window. See more about
     this below.
-  * `titleBarStyle` String - The style of window title bar. Default is `default`. Possible values are:
+  * `titleBarStyle` String (optional) - The style of window title bar. Default is `default`. Possible values are:
     * `default` - Results in the standard gray opaque Mac title
       bar.
     * `hidden` - Results in a hidden title bar and a full size content window, yet
@@ -195,76 +195,76 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       the top left.
     * `hidden-inset` - Results in a hidden title bar with an alternative look
       where the traffic light buttons are slightly more inset from the window edge.
-  * `thickFrame` Boolean - Use `WS_THICKFRAME` style for frameless windows on
+  * `thickFrame` Boolean (optional) - Use `WS_THICKFRAME` style for frameless windows on
     Windows, which adds standard window frame. Setting it to `false` will remove
     window shadow and window animations. Default is `true`.
-  * `webPreferences` Object - Settings of web page's features.
-    * `devTools` Boolean - Whether to enable DevTools. If it is set to `false`, can not use `BrowserWindow.webContents.openDevTools()` to open DevTools. Default is `true`.
-    * `nodeIntegration` Boolean - Whether node integration is enabled. Default
+  * `webPreferences` Object (optional) - Settings of web page's features.
+    * `devTools` Boolean (optional) - Whether to enable DevTools. If it is set to `false`, can not use `BrowserWindow.webContents.openDevTools()` to open DevTools. Default is `true`.
+    * `nodeIntegration` Boolean (optional) - Whether node integration is enabled. Default
       is `true`.
-    * `preload` String - Specifies a script that will be loaded before other
+    * `preload` String (optional) - Specifies a script that will be loaded before other
       scripts run in the page. This script will always have access to node APIs
       no matter whether node integration is turned on or off. The value should
       be the absolute file path to the script.
       When node integration is turned off, the preload script can reintroduce
       Node global symbols back to the global scope. See example
       [here](process.md#event-loaded).
-    * `session` [Session](session.md#class-session) - Sets the session used by the
+    * `session` [Session](session.md#class-session) (optional) - Sets the session used by the
       page. Instead of passing the Session object directly, you can also choose to
       use the `partition` option instead, which accepts a partition string. When
       both `session` and `partition` are provided, `session` will be preferred.
       Default is the default session.
-    * `partition` String - Sets the session used by the page according to the
+    * `partition` String (optional) - Sets the session used by the page according to the
       session's partition string. If `partition` starts with `persist:`, the page
       will use a persistent session available to all pages in the app with the
       same `partition`. If there is no `persist:` prefix, the page will use an
       in-memory session. By assigning the same `partition`, multiple pages can share
       the same session. Default is the default session.
-    * `zoomFactor` Number - The default zoom factor of the page, `3.0` represents
+    * `zoomFactor` Number (optional) - The default zoom factor of the page, `3.0` represents
       `300%`. Default is `1.0`.
-    * `javascript` Boolean - Enables JavaScript support. Default is `true`.
-    * `webSecurity` Boolean - When `false`, it will disable the
+    * `javascript` Boolean (optional) - Enables JavaScript support. Default is `true`.
+    * `webSecurity` Boolean (optional) - When `false`, it will disable the
       same-origin policy (usually using testing websites by people), and set
       `allowDisplayingInsecureContent` and `allowRunningInsecureContent` to
       `true` if these two options are not set by user. Default is `true`.
-    * `allowDisplayingInsecureContent` Boolean - Allow an https page to display
+    * `allowDisplayingInsecureContent` Boolean (optional) - Allow an https page to display
       content like images from http URLs. Default is `false`.
-    * `allowRunningInsecureContent` Boolean - Allow an https page to run
+    * `allowRunningInsecureContent` Boolean (optional) - Allow an https page to run
       JavaScript, CSS or plugins from http URLs. Default is `false`.
-    * `images` Boolean - Enables image support. Default is `true`.
-    * `textAreasAreResizable` Boolean - Make TextArea elements resizable. Default
+    * `images` Boolean (optional) - Enables image support. Default is `true`.
+    * `textAreasAreResizable` Boolean (optional) - Make TextArea elements resizable. Default
       is `true`.
-    * `webgl` Boolean - Enables WebGL support. Default is `true`.
-    * `webaudio` Boolean - Enables WebAudio support. Default is `true`.
-    * `plugins` Boolean - Whether plugins should be enabled. Default is `false`.
-    * `experimentalFeatures` Boolean - Enables Chromium's experimental features.
+    * `webgl` Boolean (optional) - Enables WebGL support. Default is `true`.
+    * `webaudio` Boolean (optional) - Enables WebAudio support. Default is `true`.
+    * `plugins` Boolean (optional) - Whether plugins should be enabled. Default is `false`.
+    * `experimentalFeatures` Boolean (optional) - Enables Chromium's experimental features.
       Default is `false`.
-    * `experimentalCanvasFeatures` Boolean - Enables Chromium's experimental
+    * `experimentalCanvasFeatures` Boolean (optional) - Enables Chromium's experimental
       canvas features. Default is `false`.
-    * `scrollBounce` Boolean - Enables scroll bounce (rubber banding) effect on
+    * `scrollBounce` Boolean (optional) - Enables scroll bounce (rubber banding) effect on
       macOS. Default is `false`.
-    * `blinkFeatures` String - A list of feature strings separated by `,`, like
+    * `blinkFeatures` String (optional) - A list of feature strings separated by `,`, like
       `CSSVariables,KeyboardEventKey` to enable. The full list of supported feature
       strings can be found in the [RuntimeEnabledFeatures.in][blink-feature-string]
       file.
-    * `disableBlinkFeatures` String - A list of feature strings separated by `,`,
+    * `disableBlinkFeatures` String (optional) - A list of feature strings separated by `,`,
       like `CSSVariables,KeyboardEventKey` to disable. The full list of supported
       feature strings can be found in the
       [RuntimeEnabledFeatures.in][blink-feature-string] file.
-    * `defaultFontFamily` Object - Sets the default font for the font-family.
-      * `standard` String - Defaults to `Times New Roman`.
-      * `serif` String - Defaults to `Times New Roman`.
-      * `sansSerif` String - Defaults to `Arial`.
-      * `monospace` String - Defaults to `Courier New`.
-    * `defaultFontSize` Integer - Defaults to `16`.
-    * `defaultMonospaceFontSize` Integer - Defaults to `13`.
-    * `minimumFontSize` Integer - Defaults to `0`.
-    * `defaultEncoding` String - Defaults to `ISO-8859-1`.
-    * `backgroundThrottling` Boolean - Whether to throttle animations and timers
+    * `defaultFontFamily` Object (optional) - Sets the default font for the font-family.
+      * `standard` String (optional) - Defaults to `Times New Roman`.
+      * `serif` String (optional) - Defaults to `Times New Roman`.
+      * `sansSerif` String (optional) - Defaults to `Arial`.
+      * `monospace` String (optional) - Defaults to `Courier New`.
+    * `defaultFontSize` Integer (optional) - Defaults to `16`.
+    * `defaultMonospaceFontSize` Integer (optional) - Defaults to `13`.
+    * `minimumFontSize` Integer (optional) - Defaults to `0`.
+    * `defaultEncoding` String (optional) - Defaults to `ISO-8859-1`.
+    * `backgroundThrottling` Boolean (optional) - Whether to throttle animations and timers
       when the page becomes background. Defaults to `true`.
-    * `offscreen` Boolean - Whether to enable offscreen rendering for the browser
+    * `offscreen` Boolean (optional) - Whether to enable offscreen rendering for the browser
       window. Defaults to `false`.
-    * `sandbox` Boolean - Whether to enable Chromium OS-level sandbox.
+    * `sandbox` Boolean (optional) - Whether to enable Chromium OS-level sandbox.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from
@@ -945,7 +945,7 @@ bar will become gray when set to `true`.
 
 #### `win.isDocumentEdited()` _macOS_
 
-Whether `Boolean` - Whether the window's document has been edited.
+Returns `Boolean` - Whether the window's document has been edited.
 
 #### `win.focusOnWebView()`
 
@@ -961,11 +961,11 @@ Same as `webContents.capturePage([rect, ]callback)`.
 
 #### `win.loadURL(url[, options])`
 
-* `url` URL
+* `url` String
 * `options` Object (optional)
-  * `httpReferrer` String - A HTTP Referrer url.
-  * `userAgent` String - A user agent originating the request.
-  * `extraHeaders` String - Extra headers separated by "\n"
+  * `httpReferrer` String (optional) - A HTTP Referrer url.
+  * `userAgent` String (optional) - A user agent originating the request.
+  * `extraHeaders` String (optional) - Extra headers separated by "\n"
 
 Same as `webContents.loadURL(url[, options])`.
 
@@ -1001,7 +1001,7 @@ menu bar.
 
 * `progress` Double
 * `options` Object (optional)
-  * `mode` String _Windows_ - Mode for the progress bar (`none`, `normal`, `indeterminate`, `error`, or `paused`)
+  * `mode` String _Windows_ - Mode for the progress bar. Can be `none`, `normal`, `indeterminate`, `error`, or `paused`.
 
 Sets progress value in progress bar. Valid range is [0, 1.0].
 

--- a/test/fixtures/electron/docs/api/browser-window.md
+++ b/test/fixtures/electron/docs/api/browser-window.md
@@ -1,0 +1,1190 @@
+# BrowserWindow
+
+> Create and control browser windows.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+```javascript
+// In the main process.
+const {BrowserWindow} = require('electron')
+
+// Or use `remote` from the renderer process.
+// const {BrowserWindow} = require('electron').remote
+
+let win = new BrowserWindow({width: 800, height: 600})
+win.on('closed', () => {
+  win = null
+})
+
+// Load a remote URL
+win.loadURL('https://github.com')
+
+// Or load a local HTML file
+win.loadURL(`file://${__dirname}/app/index.html`)
+```
+
+## Frameless window
+
+To create a window without chrome, or a transparent window in arbitrary shape,
+you can use the [Frameless Window](frameless-window.md) API.
+
+## Showing window gracefully
+
+When loading a page in window directly, users will see the progress of loading
+page, which is not good experience for native app. To make the window display
+without visual flash, there are two solutions for different situations.
+
+### Using `ready-to-show` event
+
+While loading the page, the `ready-to-show` event will be emitted when renderer
+process has done drawing for the first time, showing window after this event
+will have no visual flash:
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow({show: false})
+win.once('ready-to-show', () => {
+  win.show()
+})
+```
+
+This is event is usually emitted after the `did-finish-load` event, but for
+pages with many remote resources, it may be emitted before the `did-finish-load`
+event.
+
+### Setting `backgroundColor`
+
+For a complex app, the `ready-to-show` event could be emitted too late, making
+the app feel slow. In this case, it is recommended to show the window
+immediately, and use a `backgroundColor` close to your app's background:
+
+```javascript
+const {BrowserWindow} = require('electron')
+
+let win = new BrowserWindow({backgroundColor: '#2e2c29'})
+win.loadURL('https://github.com')
+```
+
+Note that even for apps that use `ready-to-show` event, it is still recommended
+to set `backgroundColor` to make app feel more native.
+
+## Parent and child windows
+
+By using `parent` option, you can create child windows:
+
+```javascript
+const {BrowserWindow} = require('electron')
+
+let top = new BrowserWindow()
+let child = new BrowserWindow({parent: top})
+child.show()
+top.show()
+```
+
+The `child` window will always show on top of the `top` window.
+
+### Modal windows
+
+A modal window is a child window that disables parent window, to create a modal
+window, you have to set both `parent` and `modal` options:
+
+```javascript
+const {BrowserWindow} = require('electron')
+
+let child = new BrowserWindow({parent: top, modal: true, show: false})
+child.loadURL('https://github.com')
+child.once('ready-to-show', () => {
+  child.show()
+})
+```
+
+### Platform notices
+
+* On macOS the child windows will keep the relative position to parent window
+  when parent window moves, while on Windows and Linux child windows will not
+  move.
+* On Windows it is not supported to change parent window dynamically.
+* On Linux the type of modal windows will be changed to `dialog`.
+* On Linux many desktop environments do not support hiding a modal window.
+
+## Class: BrowserWindow
+
+`BrowserWindow` is an
+[EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter).
+
+It creates a new `BrowserWindow` with native properties as set by the `options`.
+
+### `new BrowserWindow([options])`
+
+* `options` Object
+  * `width` Integer - Window's width in pixels. Default is `800`.
+  * `height` Integer - Window's height in pixels. Default is `600`.
+  * `x` Integer (**required** if y is used) - Window's left offset from screen.
+    Default is to center the window.
+  * `y` Integer (**required** if x is used) - Window's top offset from screen.
+    Default is to center the window.
+  * `useContentSize` Boolean - The `width` and `height` would be used as web
+    page's size, which means the actual window's size will include window
+    frame's size and be slightly larger. Default is `false`.
+  * `center` Boolean - Show window in the center of the screen.
+  * `minWidth` Integer - Window's minimum width. Default is `0`.
+  * `minHeight` Integer - Window's minimum height. Default is `0`.
+  * `maxWidth` Integer - Window's maximum width. Default is no limit.
+  * `maxHeight` Integer - Window's maximum height. Default is no limit.
+  * `resizable` Boolean - Whether window is resizable. Default is `true`.
+  * `movable` Boolean - Whether window is movable. This is not implemented
+    on Linux. Default is `true`.
+  * `minimizable` Boolean - Whether window is minimizable. This is not
+    implemented on Linux. Default is `true`.
+  * `maximizable` Boolean - Whether window is maximizable. This is not
+    implemented on Linux. Default is `true`.
+  * `closable` Boolean - Whether window is closable. This is not implemented
+    on Linux. Default is `true`.
+  * `focusable` Boolean - Whether the window can be focused. Default is
+    `true`. On Windows setting `focusable: false` also implies setting
+    `skipTaskbar: true`. On Linux setting `focusable: false` makes the window
+    stop interacting with wm, so the window will always stay on top in all
+    workspaces.
+  * `alwaysOnTop` Boolean - Whether the window should always stay on top of
+    other windows. Default is `false`.
+  * `fullscreen` Boolean - Whether the window should show in fullscreen. When
+    explicitly set to `false` the fullscreen button will be hidden or disabled
+    on macOS. Default is `false`.
+  * `fullscreenable` Boolean - Whether the window can be put into fullscreen
+    mode. On macOS, also whether the maximize/zoom button should toggle full
+    screen mode or maximize window. Default is `true`.
+  * `skipTaskbar` Boolean - Whether to show the window in taskbar. Default is
+    `false`.
+  * `kiosk` Boolean - The kiosk mode. Default is `false`.
+  * `title` String - Default window title. Default is `"Electron"`.
+  * `icon` [NativeImage](native-image.md) - The window icon. On Windows it is
+    recommended to use `ICO` icons to get best visual effects, you can also
+    leave it undefined so the executable's icon will be used.
+  * `show` Boolean - Whether window should be shown when created. Default is
+    `true`.
+  * `frame` Boolean - Specify `false` to create a
+    [Frameless Window](frameless-window.md). Default is `true`.
+  * `parent` BrowserWindow - Specify parent window. Default is `null`.
+  * `modal` Boolean - Whether this is a modal window. This only works when the
+    window is a child window. Default is `false`.
+  * `acceptFirstMouse` Boolean - Whether the web view accepts a single
+    mouse-down event that simultaneously activates the window. Default is
+    `false`.
+  * `disableAutoHideCursor` Boolean - Whether to hide cursor when typing.
+    Default is `false`.
+  * `autoHideMenuBar` Boolean - Auto hide the menu bar unless the `Alt`
+    key is pressed. Default is `false`.
+  * `enableLargerThanScreen` Boolean - Enable the window to be resized larger
+    than screen. Default is `false`.
+  * `backgroundColor` String - Window's background color as Hexadecimal value,
+    like `#66CD00` or `#FFF` or `#80FFFFFF` (alpha is supported). Default is
+    `#FFF` (white).
+  * `hasShadow` Boolean - Whether window should have a shadow. This is only
+    implemented on macOS. Default is `true`.
+  * `darkTheme` Boolean - Forces using dark theme for the window, only works on
+    some GTK+3 desktop environments. Default is `false`.
+  * `transparent` Boolean - Makes the window [transparent](frameless-window.md).
+    Default is `false`.
+  * `type` String - The type of window, default is normal window. See more about
+    this below.
+  * `titleBarStyle` String - The style of window title bar. Default is `default`. Possible values are:
+    * `default` - Results in the standard gray opaque Mac title
+      bar.
+    * `hidden` - Results in a hidden title bar and a full size content window, yet
+      the title bar still has the standard window controls ("traffic lights") in
+      the top left.
+    * `hidden-inset` - Results in a hidden title bar with an alternative look
+      where the traffic light buttons are slightly more inset from the window edge.
+  * `thickFrame` Boolean - Use `WS_THICKFRAME` style for frameless windows on
+    Windows, which adds standard window frame. Setting it to `false` will remove
+    window shadow and window animations. Default is `true`.
+  * `webPreferences` Object - Settings of web page's features.
+    * `devTools` Boolean - Whether to enable DevTools. If it is set to `false`, can not use `BrowserWindow.webContents.openDevTools()` to open DevTools. Default is `true`.
+    * `nodeIntegration` Boolean - Whether node integration is enabled. Default
+      is `true`.
+    * `preload` String - Specifies a script that will be loaded before other
+      scripts run in the page. This script will always have access to node APIs
+      no matter whether node integration is turned on or off. The value should
+      be the absolute file path to the script.
+      When node integration is turned off, the preload script can reintroduce
+      Node global symbols back to the global scope. See example
+      [here](process.md#event-loaded).
+    * `session` [Session](session.md#class-session) - Sets the session used by the
+      page. Instead of passing the Session object directly, you can also choose to
+      use the `partition` option instead, which accepts a partition string. When
+      both `session` and `partition` are provided, `session` will be preferred.
+      Default is the default session.
+    * `partition` String - Sets the session used by the page according to the
+      session's partition string. If `partition` starts with `persist:`, the page
+      will use a persistent session available to all pages in the app with the
+      same `partition`. If there is no `persist:` prefix, the page will use an
+      in-memory session. By assigning the same `partition`, multiple pages can share
+      the same session. Default is the default session.
+    * `zoomFactor` Number - The default zoom factor of the page, `3.0` represents
+      `300%`. Default is `1.0`.
+    * `javascript` Boolean - Enables JavaScript support. Default is `true`.
+    * `webSecurity` Boolean - When `false`, it will disable the
+      same-origin policy (usually using testing websites by people), and set
+      `allowDisplayingInsecureContent` and `allowRunningInsecureContent` to
+      `true` if these two options are not set by user. Default is `true`.
+    * `allowDisplayingInsecureContent` Boolean - Allow an https page to display
+      content like images from http URLs. Default is `false`.
+    * `allowRunningInsecureContent` Boolean - Allow an https page to run
+      JavaScript, CSS or plugins from http URLs. Default is `false`.
+    * `images` Boolean - Enables image support. Default is `true`.
+    * `textAreasAreResizable` Boolean - Make TextArea elements resizable. Default
+      is `true`.
+    * `webgl` Boolean - Enables WebGL support. Default is `true`.
+    * `webaudio` Boolean - Enables WebAudio support. Default is `true`.
+    * `plugins` Boolean - Whether plugins should be enabled. Default is `false`.
+    * `experimentalFeatures` Boolean - Enables Chromium's experimental features.
+      Default is `false`.
+    * `experimentalCanvasFeatures` Boolean - Enables Chromium's experimental
+      canvas features. Default is `false`.
+    * `scrollBounce` Boolean - Enables scroll bounce (rubber banding) effect on
+      macOS. Default is `false`.
+    * `blinkFeatures` String - A list of feature strings separated by `,`, like
+      `CSSVariables,KeyboardEventKey` to enable. The full list of supported feature
+      strings can be found in the [RuntimeEnabledFeatures.in][blink-feature-string]
+      file.
+    * `disableBlinkFeatures` String - A list of feature strings separated by `,`,
+      like `CSSVariables,KeyboardEventKey` to disable. The full list of supported
+      feature strings can be found in the
+      [RuntimeEnabledFeatures.in][blink-feature-string] file.
+    * `defaultFontFamily` Object - Sets the default font for the font-family.
+      * `standard` String - Defaults to `Times New Roman`.
+      * `serif` String - Defaults to `Times New Roman`.
+      * `sansSerif` String - Defaults to `Arial`.
+      * `monospace` String - Defaults to `Courier New`.
+    * `defaultFontSize` Integer - Defaults to `16`.
+    * `defaultMonospaceFontSize` Integer - Defaults to `13`.
+    * `minimumFontSize` Integer - Defaults to `0`.
+    * `defaultEncoding` String - Defaults to `ISO-8859-1`.
+    * `backgroundThrottling` Boolean - Whether to throttle animations and timers
+      when the page becomes background. Defaults to `true`.
+    * `offscreen` Boolean - Whether to enable offscreen rendering for the browser
+      window. Defaults to `false`.
+    * `sandbox` Boolean - Whether to enable Chromium OS-level sandbox.
+
+When setting minimum or maximum window size with `minWidth`/`maxWidth`/
+`minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from
+passing a size that does not follow size constraints to `setBounds`/`setSize` or
+to the constructor of `BrowserWindow`.
+
+The possible values and behaviors of the `type` option are platform dependent.
+Possible values are:
+
+* On Linux, possible types are `desktop`, `dock`, `toolbar`, `splash`,
+  `notification`.
+* On macOS, possible types are `desktop`, `textured`.
+  * The `textured` type adds metal gradient appearance
+    (`NSTexturedBackgroundWindowMask`).
+  * The `desktop` type places the window at the desktop background window level
+    (`kCGDesktopWindowLevel - 1`). Note that desktop window will not receive
+    focus, keyboard or mouse events, but you can use `globalShortcut` to receive
+    input sparingly.
+* On Windows, possible type is `toolbar`.
+
+### Instance Events
+
+Objects created with `new BrowserWindow` emit the following events:
+
+**Note:** Some events are only available on specific operating systems and are
+labeled as such.
+
+#### Event: 'page-title-updated'
+
+Returns:
+
+* `event` Event
+* `title` String
+
+Emitted when the document changed its title, calling `event.preventDefault()`
+will prevent the native window's title from changing.
+
+#### Event: 'close'
+
+Returns:
+
+* `event` Event
+
+Emitted when the window is going to be closed. It's emitted before the
+`beforeunload` and `unload` event of the DOM. Calling `event.preventDefault()`
+will cancel the close.
+
+Usually you would want to use the `beforeunload` handler to decide whether the
+window should be closed, which will also be called when the window is
+reloaded. In Electron, returning any value other than `undefined` would cancel the
+close. For example:
+
+```javascript
+window.onbeforeunload = (e) => {
+  console.log('I do not want to be closed')
+
+  // Unlike usual browsers that a message box will be prompted to users, returning
+  // a non-void value will silently cancel the close.
+  // It is recommended to use the dialog API to let the user confirm closing the
+  // application.
+  e.returnValue = false
+}
+```
+
+#### Event: 'closed'
+
+Emitted when the window is closed. After you have received this event you should
+remove the reference to the window and avoid using it any more.
+
+#### Event: 'unresponsive'
+
+Emitted when the web page becomes unresponsive.
+
+#### Event: 'responsive'
+
+Emitted when the unresponsive web page becomes responsive again.
+
+#### Event: 'blur'
+
+Emitted when the window loses focus.
+
+#### Event: 'focus'
+
+Emitted when the window gains focus.
+
+#### Event: 'show'
+
+Emitted when the window is shown.
+
+#### Event: 'hide'
+
+Emitted when the window is hidden.
+
+#### Event: 'ready-to-show'
+
+Emitted when the web page has been rendered and window can be displayed without
+a visual flash.
+
+#### Event: 'maximize'
+
+Emitted when window is maximized.
+
+#### Event: 'unmaximize'
+
+Emitted when the window exits from a maximized state.
+
+#### Event: 'minimize'
+
+Emitted when the window is minimized.
+
+#### Event: 'restore'
+
+Emitted when the window is restored from a minimized state.
+
+#### Event: 'resize'
+
+Emitted when the window is being resized.
+
+#### Event: 'move'
+
+Emitted when the window is being moved to a new position.
+
+__Note__: On macOS this event is just an alias of `moved`.
+
+#### Event: 'moved' _macOS_
+
+Emitted once when the window is moved to a new position.
+
+#### Event: 'enter-full-screen'
+
+Emitted when the window enters a full-screen state.
+
+#### Event: 'leave-full-screen'
+
+Emitted when the window leaves a full-screen state.
+
+#### Event: 'enter-html-full-screen'
+
+Emitted when the window enters a full-screen state triggered by HTML API.
+
+#### Event: 'leave-html-full-screen'
+
+Emitted when the window leaves a full-screen state triggered by HTML API.
+
+#### Event: 'app-command' _Windows_
+
+Returns:
+
+* `event` Event
+* `command` String
+
+Emitted when an [App Command](https://msdn.microsoft.com/en-us/library/windows/desktop/ms646275(v=vs.85).aspx)
+is invoked. These are typically related to keyboard media keys or browser
+commands, as well as the "Back" button built into some mice on Windows.
+
+Commands are lowercased, underscores are replaced with hyphens, and the
+`APPCOMMAND_` prefix is stripped off.
+e.g. `APPCOMMAND_BROWSER_BACKWARD` is emitted as `browser-backward`.
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow()
+win.on('app-command', (e, cmd) => {
+  // Navigate the window back when the user hits their mouse back button
+  if (cmd === 'browser-backward' && win.webContents.canGoBack()) {
+    win.webContents.goBack()
+  }
+})
+```
+
+#### Event: 'scroll-touch-begin' _macOS_
+
+Emitted when scroll wheel event phase has begun.
+
+#### Event: 'scroll-touch-end' _macOS_
+
+Emitted when scroll wheel event phase has ended.
+
+#### Event: 'scroll-touch-edge' _macOS_
+
+Emitted when scroll wheel event phase filed upon reaching the edge of element.
+
+#### Event: 'swipe' _macOS_
+
+Returns:
+
+* `event` Event
+* `direction` String
+
+Emitted on 3-finger swipe. Possible directions are `up`, `right`, `down`, `left`.
+
+### Static Methods
+
+The `BrowserWindow` class has the following static methods:
+
+#### `BrowserWindow.getAllWindows()`
+
+Returns `BrowserWindow[]` - An array of all opened browser windows.
+
+#### `BrowserWindow.getFocusedWindow()`
+
+Returns `BrowserWindow` - The window that is focused in this application, otherwise returns `null`.
+
+#### `BrowserWindow.fromWebContents(webContents)`
+
+* `webContents` [WebContents](web-contents.md)
+
+Returns `BrowserWindow` - The window that owns the given `webContents`.
+
+#### `BrowserWindow.fromId(id)`
+
+* `id` Integer
+
+Returns `BrowserWindow` - The window with the given `id`.
+
+#### `BrowserWindow.addDevToolsExtension(path)`
+
+* `path` String
+
+Adds DevTools extension located at `path`, and returns extension's name.
+
+The extension will be remembered so you only need to call this API once, this
+API is not for programming use. If you try to add an extension that has already
+been loaded, this method will not return and instead log a warning to the
+console.
+
+The method will also not return if the extension's manifest is missing or incomplete.
+
+**Note:** This API cannot be called before the `ready` event of the `app` module
+is emitted.
+
+#### `BrowserWindow.removeDevToolsExtension(name)`
+
+* `name` String
+
+Remove a DevTools extension by name.
+
+**Note:** This API cannot be called before the `ready` event of the `app` module
+is emitted.
+
+#### `BrowserWindow.getDevToolsExtensions()`
+
+Returns `Object` - The keys are the extension names and each value is
+an Object containing `name` and `version` properties.
+
+To check if a DevTools extension is installed you can run the following:
+
+```javascript
+const {BrowserWindow} = require('electron')
+
+let installed = BrowserWindow.getDevToolsExtensions().hasOwnProperty('devtron')
+console.log(installed)
+```
+
+**Note:** This API cannot be called before the `ready` event of the `app` module
+is emitted.
+
+### Instance Properties
+
+Objects created with `new BrowserWindow` have the following properties:
+
+```javascript
+const {BrowserWindow} = require('electron')
+// In this example `win` is our instance
+let win = new BrowserWindow({width: 800, height: 600})
+win.loadURL('https://github.com')
+```
+
+#### `win.webContents`
+
+A `WebContents` object this window owns. All web page related events and
+operations will be done via it.
+
+See the [`webContents` documentation](web-contents.md) for its methods and
+events.
+
+#### `win.id`
+
+A `Integer` representing the unique ID of the window.
+
+### Instance Methods
+
+Objects created with `new BrowserWindow` have the following instance methods:
+
+**Note:** Some methods are only available on specific operating systems and are
+labeled as such.
+
+#### `win.destroy()`
+
+Force closing the window, the `unload` and `beforeunload` event won't be emitted
+for the web page, and `close` event will also not be emitted
+for this window, but it guarantees the `closed` event will be emitted.
+
+#### `win.close()`
+
+Try to close the window. This has the same effect as a user manually clicking
+the close button of the window. The web page may cancel the close though. See
+the [close event](#event-close).
+
+#### `win.focus()`
+
+Focuses on the window.
+
+#### `win.blur()`
+
+Removes focus from the window.
+
+#### `win.isFocused()`
+
+Returns `Boolean` - Whether the window is focused.
+
+#### `win.isDestroyed()`
+
+Returns `Boolean` - Whether the window is destroyed.
+
+#### `win.show()`
+
+Shows and gives focus to the window.
+
+#### `win.showInactive()`
+
+Shows the window but doesn't focus on it.
+
+#### `win.hide()`
+
+Hides the window.
+
+#### `win.isVisible()`
+
+Returns `Boolean` - Whether the window is visible to the user.
+
+#### `win.isModal()`
+
+Returns `Boolean` - Whether current window is a modal window.
+
+#### `win.maximize()`
+
+Maximizes the window.
+
+#### `win.unmaximize()`
+
+Unmaximizes the window.
+
+#### `win.isMaximized()`
+
+Returns `Boolean` - Whether the window is maximized.
+
+#### `win.minimize()`
+
+Minimizes the window. On some platforms the minimized window will be shown in
+the Dock.
+
+#### `win.restore()`
+
+Restores the window from minimized state to its previous state.
+
+#### `win.isMinimized()`
+
+Returns `Boolean` - Whether the window is minimized.
+
+#### `win.setFullScreen(flag)`
+
+* `flag` Boolean
+
+Sets whether the window should be in fullscreen mode.
+
+#### `win.isFullScreen()`
+
+Returns `Boolean` - Whether the window is in fullscreen mode.
+
+#### `win.setAspectRatio(aspectRatio[, extraSize])` _macOS_
+
+* `aspectRatio` Float - The aspect ratio to maintain for some portion of the
+content view.
+* `extraSize` Object (optional) - The extra size not to be included while
+maintaining the aspect ratio.
+  * `width` Integer
+  * `height` Integer
+
+This will make a window maintain an aspect ratio. The extra size allows a
+developer to have space, specified in pixels, not included within the aspect
+ratio calculations. This API already takes into account the difference between a
+window's size and its content size.
+
+Consider a normal window with an HD video player and associated controls.
+Perhaps there are 15 pixels of controls on the left edge, 25 pixels of controls
+on the right edge and 50 pixels of controls below the player. In order to
+maintain a 16:9 aspect ratio (standard aspect ratio for HD @1920x1080) within
+the player itself we would call this function with arguments of 16/9 and
+[ 40, 50 ]. The second argument doesn't care where the extra width and height
+are within the content view--only that they exist. Just sum any extra width and
+height areas you have within the overall content view.
+
+#### `win.previewFile(path[, displayName])` _macOS_
+
+* `path` String - The absolute path to the file to preview with QuickLook. This
+  is important as Quick Look uses the file name and file extension on the path
+  to determine the content type of the file to open.
+* `displayName` String (Optional) - The name of the file to display on the
+  Quick Look modal view. This is purely visual and does not affect the content
+  type of the file. Defaults to `path`.
+
+Uses [Quick Look][quick-look] to preview a file at a given path.
+
+#### `win.setBounds(bounds[, animate])`
+
+* `bounds` [Rectangle](structures/rectangle.md)
+* `animate` Boolean (optional) _macOS_
+
+Resizes and moves the window to the supplied bounds
+
+#### `win.getBounds()`
+
+Returns [`Rectangle`](structures/rectangle.md)
+
+#### `win.setContentBounds(bounds[, animate])`
+
+* `bounds` [Rectangle](structures/rectangle.md)
+* `animate` Boolean (optional) _macOS_
+
+Resizes and moves the window's client area (e.g. the web page) to
+the supplied bounds.
+
+#### `win.getContentBounds()`
+
+Returns [`Rectangle`](structures/rectangle.md)
+
+#### `win.setSize(width, height[, animate])`
+
+* `width` Integer
+* `height` Integer
+* `animate` Boolean (optional) _macOS_
+
+Resizes the window to `width` and `height`.
+
+#### `win.getSize()`
+
+Returns `Integer[]` - Contains the window's width and height.
+
+#### `win.setContentSize(width, height[, animate])`
+
+* `width` Integer
+* `height` Integer
+* `animate` Boolean (optional) _macOS_
+
+Resizes the window's client area (e.g. the web page) to `width` and `height`.
+
+#### `win.getContentSize()`
+
+Returns `Integer[]` - Contains the window's client area's width and height.
+
+#### `win.setMinimumSize(width, height)`
+
+* `width` Integer
+* `height` Integer
+
+Sets the minimum size of window to `width` and `height`.
+
+#### `win.getMinimumSize()`
+
+Returns `Integer[]` - Contains the window's minimum width and height.
+
+#### `win.setMaximumSize(width, height)`
+
+* `width` Integer
+* `height` Integer
+
+Sets the maximum size of window to `width` and `height`.
+
+#### `win.getMaximumSize()`
+
+Returns `Integer[]` - Contains the window's maximum width and height.
+
+#### `win.setResizable(resizable)`
+
+* `resizable` Boolean
+
+Sets whether the window can be manually resized by user.
+
+#### `win.isResizable()`
+
+Returns `Boolean` - Whether the window can be manually resized by user.
+
+#### `win.setMovable(movable)` _macOS_ _Windows_
+
+* `movable` Boolean
+
+Sets whether the window can be moved by user. On Linux does nothing.
+
+#### `win.isMovable()` _macOS_ _Windows_
+
+Returns `Boolean` - Whether the window can be moved by user.
+
+On Linux always returns `true`.
+
+#### `win.setMinimizable(minimizable)` _macOS_ _Windows_
+
+* `minimizable` Boolean
+
+Sets whether the window can be manually minimized by user. On Linux does
+nothing.
+
+#### `win.isMinimizable()` _macOS_ _Windows_
+
+Returns `Boolean` - Whether the window can be manually minimized by user
+
+On Linux always returns `true`.
+
+#### `win.setMaximizable(maximizable)` _macOS_ _Windows_
+
+* `maximizable` Boolean
+
+Sets whether the window can be manually maximized by user. On Linux does
+nothing.
+
+#### `win.isMaximizable()` _macOS_ _Windows_
+
+Returns `Boolean` - Whether the window can be manually maximized by user.
+
+On Linux always returns `true`.
+
+#### `win.setFullScreenable(fullscreenable)`
+
+* `fullscreenable` Boolean
+
+Sets whether the maximize/zoom window button toggles fullscreen mode or
+maximizes the window.
+
+#### `win.isFullScreenable()`
+
+Returns `Boolean` - Whether the maximize/zoom window button toggles fullscreen mode or
+maximizes the window.
+
+#### `win.setClosable(closable)` _macOS_ _Windows_
+
+* `closable` Boolean
+
+Sets whether the window can be manually closed by user. On Linux does nothing.
+
+#### `win.isClosable()` _macOS_ _Windows_
+
+Returns `Boolean` - Whether the window can be manually closed by user.
+
+On Linux always returns `true`.
+
+#### `win.setAlwaysOnTop(flag[, level])`
+
+* `flag` Boolean
+* `level` String (optional) _macOS_ - Values include `normal`, `floating`,
+  `torn-off-menu`, `modal-panel`, `main-menu`, `status`, `pop-up-menu`,
+  `screen-saver`, and `dock`. The default is `floating`. See the
+  [macOS docs][window-levels] for more details.
+
+Sets whether the window should show always on top of other windows. After
+setting this, the window is still a normal window, not a toolbox window which
+can not be focused on.
+
+#### `win.isAlwaysOnTop()`
+
+Returns `Boolean` - Whether the window is always on top of other windows.
+
+#### `win.center()`
+
+Moves window to the center of the screen.
+
+#### `win.setPosition(x, y[, animate])`
+
+* `x` Integer
+* `y` Integer
+* `animate` Boolean (optional) _macOS_
+
+Moves window to `x` and `y`.
+
+#### `win.getPosition()`
+
+Returns `Integer[]` - Contains the window's current position.
+
+#### `win.setTitle(title)`
+
+* `title` String
+
+Changes the title of native window to `title`.
+
+#### `win.getTitle()`
+
+Returns `String` - The title of the native window.
+
+**Note:** The title of web page can be different from the title of the native
+window.
+
+#### `win.setSheetOffset(offsetY[, offsetX])` _macOS_
+
+* `offsetY` Float
+* `offsetX` Float (optional)
+
+Changes the attachment point for sheets on macOS. By default, sheets are
+attached just below the window frame, but you may want to display them beneath
+a HTML-rendered toolbar. For example:
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow()
+
+let toolbarRect = document.getElementById('toolbar').getBoundingClientRect()
+win.setSheetOffset(toolbarRect.height)
+```
+
+#### `win.flashFrame(flag)`
+
+* `flag` Boolean
+
+Starts or stops flashing the window to attract user's attention.
+
+#### `win.setSkipTaskbar(skip)`
+
+* `skip` Boolean
+
+Makes the window not show in the taskbar.
+
+#### `win.setKiosk(flag)`
+
+* `flag` Boolean
+
+Enters or leaves the kiosk mode.
+
+#### `win.isKiosk()`
+
+Returns `Boolean` - Whether the window is in kiosk mode.
+
+#### `win.getNativeWindowHandle()`
+
+Returns `Buffer` - The platform-specific handle of the window.
+
+The native type of the handle is `HWND` on Windows, `NSView*` on macOS, and
+`Window` (`unsigned long`) on Linux.
+
+#### `win.hookWindowMessage(message, callback)` _Windows_
+
+* `message` Integer
+* `callback` Function
+
+Hooks a windows message. The `callback` is called when
+the message is received in the WndProc.
+
+#### `win.isWindowMessageHooked(message)` _Windows_
+
+* `message` Integer
+
+Returns `Boolean` - `true` or `false` depending on whether the message is hooked.
+
+#### `win.unhookWindowMessage(message)` _Windows_
+
+* `message` Integer
+
+Unhook the window message.
+
+#### `win.unhookAllWindowMessages()` _Windows_
+
+Unhooks all of the window messages.
+
+#### `win.setRepresentedFilename(filename)` _macOS_
+
+* `filename` String
+
+Sets the pathname of the file the window represents, and the icon of the file
+will show in window's title bar.
+
+#### `win.getRepresentedFilename()` _macOS_
+
+Returns `String` - The pathname of the file the window represents.
+
+#### `win.setDocumentEdited(edited)` _macOS_
+
+* `edited` Boolean
+
+Specifies whether the window’s document has been edited, and the icon in title
+bar will become gray when set to `true`.
+
+#### `win.isDocumentEdited()` _macOS_
+
+Whether `Boolean` - Whether the window's document has been edited.
+
+#### `win.focusOnWebView()`
+
+#### `win.blurWebView()`
+
+#### `win.capturePage([rect, ]callback)`
+
+* `rect` [Rectangle](structures/rectangle.md) (optional) - The bounds to capture
+* `callback` Function
+  * `image` [NativeImage](native-image.md)
+
+Same as `webContents.capturePage([rect, ]callback)`.
+
+#### `win.loadURL(url[, options])`
+
+* `url` URL
+* `options` Object (optional)
+  * `httpReferrer` String - A HTTP Referrer url.
+  * `userAgent` String - A user agent originating the request.
+  * `extraHeaders` String - Extra headers separated by "\n"
+
+Same as `webContents.loadURL(url[, options])`.
+
+The `url` can be a remote address (e.g. `http://`) or a path to a local
+HTML file using the `file://` protocol.
+
+To ensure that file URLs are properly formatted, it is recommended to use
+Node's [`url.format`](https://nodejs.org/api/url.html#url_url_format_urlobject)
+method:
+
+```javascript
+let url = require('url').format({
+  protocol: 'file',
+  slashes: true,
+  pathname: require('path').join(__dirname, 'index.html')
+})
+
+win.loadURL(url)
+```
+
+#### `win.reload()`
+
+Same as `webContents.reload`.
+
+#### `win.setMenu(menu)` _Linux_ _Windows_
+
+* `menu` Menu
+
+Sets the `menu` as the window's menu bar, setting it to `null` will remove the
+menu bar.
+
+#### `win.setProgressBar(progress[, options])`
+
+* `progress` Double
+* `options` Object (optional)
+  * `mode` String _Windows_ - Mode for the progress bar (`none`, `normal`, `indeterminate`, `error`, or `paused`)
+
+Sets progress value in progress bar. Valid range is [0, 1.0].
+
+Remove progress bar when progress < 0;
+Change to indeterminate mode when progress > 1.
+
+On Linux platform, only supports Unity desktop environment, you need to specify
+the `*.desktop` file name to `desktopName` field in `package.json`. By default,
+it will assume `app.getName().desktop`.
+
+On Windows, a mode can be passed. Accepted values are `none`, `normal`,
+`indeterminate`, `error`, and `paused`. If you call `setProgressBar` without a
+mode set (but with a value within the valid range), `normal` will be assumed.
+
+#### `win.setOverlayIcon(overlay, description)` _Windows_
+
+* `overlay` [NativeImage](native-image.md) - the icon to display on the bottom
+right corner of the taskbar icon. If this parameter is `null`, the overlay is
+cleared
+* `description` String - a description that will be provided to Accessibility
+screen readers
+
+Sets a 16 x 16 pixel overlay onto the current taskbar icon, usually used to
+convey some sort of application status or to passively notify the user.
+
+#### `win.setHasShadow(hasShadow)` _macOS_
+
+* `hasShadow` Boolean
+
+Sets whether the window should have a shadow. On Windows and Linux does
+nothing.
+
+#### `win.hasShadow()` _macOS_
+
+Returns `Boolean` - Whether the window has a shadow.
+
+On Windows and Linux always returns
+`true`.
+
+#### `win.setThumbarButtons(buttons)` _Windows_
+
+* `buttons` [ThumbarButton[]](structures/thumbar-button.md)
+
+Returns `Boolean` - Whether the buttons were added successfully
+
+Add a thumbnail toolbar with a specified set of buttons to the thumbnail image
+of a window in a taskbar button layout. Returns a `Boolean` object indicates
+whether the thumbnail has been added successfully.
+
+The number of buttons in thumbnail toolbar should be no greater than 7 due to
+the limited room. Once you setup the thumbnail toolbar, the toolbar cannot be
+removed due to the platform's limitation. But you can call the API with an empty
+array to clean the buttons.
+
+The `buttons` is an array of `Button` objects:
+
+* `Button` Object
+  * `icon` [NativeImage](native-image.md) - The icon showing in thumbnail
+    toolbar.
+  * `click` Function
+  * `tooltip` String (optional) - The text of the button's tooltip.
+  * `flags` String[] (optional) - Control specific states and behaviors of the
+    button. By default, it is `['enabled']`.
+
+The `flags` is an array that can include following `String`s:
+
+* `enabled` - The button is active and available to the user.
+* `disabled` - The button is disabled. It is present, but has a visual state
+  indicating it will not respond to user action.
+* `dismissonclick` - When the button is clicked, the thumbnail window closes
+  immediately.
+* `nobackground` - Do not draw a button border, use only the image.
+* `hidden` - The button is not shown to the user.
+* `noninteractive` - The button is enabled but not interactive; no pressed
+  button state is drawn. This value is intended for instances where the button
+  is used in a notification.
+
+#### `win.setThumbnailClip(region)` _Windows_
+
+* `region` [Rectangle](structures/rectangle.md) - Region of the window
+
+Sets the region of the window to show as the thumbnail image displayed when
+hovering over the window in the taskbar. You can reset the thumbnail to be
+the entire window by specifying an empty region:
+`{x: 0, y: 0, width: 0, height: 0}`.
+
+#### `win.setThumbnailToolTip(toolTip)` _Windows_
+
+* `toolTip` String
+
+Sets the toolTip that is displayed when hovering over the window thumbnail
+in the taskbar.
+
+#### `win.showDefinitionForSelection()` _macOS_
+
+Same as `webContents.showDefinitionForSelection()`.
+
+#### `win.setIcon(icon)` _Windows_ _Linux_
+
+* `icon` [NativeImage](native-image.md)
+
+Changes window icon.
+
+#### `win.setAutoHideMenuBar(hide)`
+
+* `hide` Boolean
+
+Sets whether the window menu bar should hide itself automatically. Once set the
+menu bar will only show when users press the single `Alt` key.
+
+If the menu bar is already visible, calling `setAutoHideMenuBar(true)` won't
+hide it immediately.
+
+#### `win.isMenuBarAutoHide()`
+
+Returns `Boolean` - Whether menu bar automatically hides itself.
+
+#### `win.setMenuBarVisibility(visible)` _Windows_ _Linux_
+
+* `visible` Boolean
+
+Sets whether the menu bar should be visible. If the menu bar is auto-hide, users
+can still bring up the menu bar by pressing the single `Alt` key.
+
+#### `win.isMenuBarVisible()`
+
+Returns `Boolean` - Whether the menu bar is visible.
+
+#### `win.setVisibleOnAllWorkspaces(visible)`
+
+* `visible` Boolean
+
+Sets whether the window should be visible on all workspaces.
+
+**Note:** This API does nothing on Windows.
+
+#### `win.isVisibleOnAllWorkspaces()`
+
+Returns `Boolean` - Whether the window is visible on all workspaces.
+
+**Note:** This API always returns false on Windows.
+
+#### `win.setIgnoreMouseEvents(ignore)`
+
+* `ignore` Boolean
+
+Makes the window ignore all mouse events.
+
+All mouse events happened in this window will be passed to the window below
+this window, but if this window has focus, it will still receive keyboard
+events.
+
+#### `win.setContentProtection(enable)` _macOS_ _Windows_
+
+* `enable` Boolean
+
+Prevents the window contents from being captured by other apps.
+
+On macOS it sets the NSWindow's sharingType to NSWindowSharingNone.
+On Windows it calls SetWindowDisplayAffinity with `WDA_MONITOR`.
+
+#### `win.setFocusable(focusable)` _Windows_
+
+* `focusable` Boolean
+
+Changes whether the window can be focused.
+
+[blink-feature-string]: https://cs.chromium.org/chromium/src/third_party/WebKit/Source/platform/RuntimeEnabledFeatures.in
+
+#### `win.setParentWindow(parent)` _Linux_ _macOS_
+
+* `parent` BrowserWindow
+
+Sets `parent` as current window's parent window, passing `null` will turn
+current window into a top-level window.
+
+#### `win.getParentWindow()`
+
+Returns `BrowserWindow` - The parent window.
+
+#### `win.getChildWindows()`
+
+Returns `BrowserWindow[]` - All child windows.
+
+[window-levels]: https://developer.apple.com/reference/appkit/nswindow/1664726-window_levels
+[quick-look]: https://en.wikipedia.org/wiki/Quick_Look

--- a/test/fixtures/electron/docs/api/chrome-command-line-switches.md
+++ b/test/fixtures/electron/docs/api/chrome-command-line-switches.md
@@ -1,0 +1,189 @@
+# Supported Chrome Command Line Switches
+
+> Command line switches supported by Electron.
+
+You can use [app.commandLine.appendSwitch][append-switch] to append them in
+your app's main script before the [ready][ready] event of the [app][app] module
+is emitted:
+
+```javascript
+const {app} = require('electron')
+app.commandLine.appendSwitch('remote-debugging-port', '8315')
+app.commandLine.appendSwitch('host-rules', 'MAP * 127.0.0.1')
+
+app.on('ready', () => {
+  // Your code here
+})
+```
+
+## --ignore-connections-limit=`domains`
+
+Ignore the connections limit for `domains` list separated by `,`.
+
+## --disable-http-cache
+
+Disables the disk cache for HTTP requests.
+
+## --disable-http2
+
+Disable HTTP/2 and SPDY/3.1 protocols.
+
+## --debug=`port` and --debug-brk=`port`
+
+Debug-related flags, see the [Debugging the Main Process][debugging-main-process] guide for details.
+
+## --remote-debugging-port=`port`
+
+Enables remote debugging over HTTP on the specified `port`.
+
+## --js-flags=`flags`
+
+Specifies the flags passed to the Node JS engine. It has to be passed when starting
+Electron if you want to enable the `flags` in the main process.
+
+```bash
+$ electron --js-flags="--harmony_proxies --harmony_collections" your-app
+```
+
+See the [Node documentation][node-cli] or run `node --help` in your terminal for a list of available flags. Additionally, run `node --v8-options` to see a list of flags that specifically refer to Node's V8 JavaScript engine.
+
+## --proxy-server=`address:port`
+
+Use a specified proxy server, which overrides the system setting. This switch
+only affects requests with HTTP protocol, including HTTPS and WebSocket
+requests. It is also noteworthy that not all proxy servers support HTTPS and
+WebSocket requests.
+
+## --proxy-bypass-list=`hosts`
+
+Instructs Electron to bypass the proxy server for the given semi-colon-separated
+list of hosts. This flag has an effect only if used in tandem with
+`--proxy-server`.
+
+For example:
+
+```javascript
+const {app} = require('electron')
+app.commandLine.appendSwitch('proxy-bypass-list', '<local>;*.google.com;*foo.com;1.2.3.4:5678')
+```
+
+Will use the proxy server for all hosts except for local addresses (`localhost`,
+`127.0.0.1` etc.), `google.com` subdomains, hosts that contain the suffix
+`foo.com` and anything at `1.2.3.4:5678`.
+
+## --proxy-pac-url=`url`
+
+Uses the PAC script at the specified `url`.
+
+## --no-proxy-server
+
+Don't use a proxy server and always make direct connections. Overrides any other
+proxy server flags that are passed.
+
+## --host-rules=`rules`
+
+A comma-separated list of `rules` that control how hostnames are mapped.
+
+For example:
+
+* `MAP * 127.0.0.1` Forces all hostnames to be mapped to 127.0.0.1
+* `MAP *.google.com proxy` Forces all google.com subdomains to be resolved to
+  "proxy".
+* `MAP test.com [::1]:77` Forces "test.com" to resolve to IPv6 loopback. Will
+  also force the port of the resulting socket address to be 77.
+* `MAP * baz, EXCLUDE www.google.com` Remaps everything to "baz", except for
+  "www.google.com".
+
+These mappings apply to the endpoint host in a net request (the TCP connect
+and host resolver in a direct connection, and the `CONNECT` in an HTTP proxy
+connection, and the endpoint host in a `SOCKS` proxy connection).
+
+## --host-resolver-rules=`rules`
+
+Like `--host-rules` but these `rules` only apply to the host resolver.
+
+## --auth-server-whitelist=`url`
+
+A comma-separated list of servers for which integrated authentication is enabled.
+
+For example:
+
+```
+--auth-server-whitelist='*example.com, *foobar.com, *baz'
+```
+
+then any `url` ending with `example.com`, `foobar.com`, `baz` will be considered
+for integrated authentication. Without `*` prefix the url has to match exactly.
+
+## --auth-negotiate-delegate-whitelist=`url`
+
+A comma-separated list of servers for which delegation of user credentials is required.
+Without `*` prefix the url has to match exactly.
+
+## --ignore-certificate-errors
+
+Ignores certificate related errors.
+
+## --ppapi-flash-path=`path`
+
+Sets the `path` of the pepper flash plugin.
+
+## --ppapi-flash-version=`version`
+
+Sets the `version` of the pepper flash plugin.
+
+## --log-net-log=`path`
+
+Enables net log events to be saved and writes them to `path`.
+
+## --ssl-version-fallback-min=`version`
+
+Sets the minimum SSL/TLS version (`tls1`, `tls1.1` or `tls1.2`) that TLS
+fallback will accept.
+
+## --cipher-suite-blacklist=`cipher_suites`
+
+Specifies comma-separated list of SSL cipher suites to disable.
+
+## --disable-renderer-backgrounding
+
+Prevents Chromium from lowering the priority of invisible pages' renderer
+processes.
+
+This flag is global to all renderer processes, if you only want to disable
+throttling in one window, you can take the hack of
+[playing silent audio][play-silent-audio].
+
+## --enable-logging
+
+Prints Chromium's logging into console.
+
+This switch can not be used in `app.commandLine.appendSwitch` since it is parsed
+earlier than user's app is loaded, but you can set the `ELECTRON_ENABLE_LOGGING`
+environment variable to achieve the same effect.
+
+## --v=`log_level`
+
+Gives the default maximal active V-logging level; 0 is the default. Normally
+positive values are used for V-logging levels.
+
+This switch only works when `--enable-logging` is also passed.
+
+## --vmodule=`pattern`
+
+Gives the per-module maximal V-logging levels to override the value given by
+`--v`. E.g. `my_module=2,foo*=3` would change the logging level for all code in
+source files `my_module.*` and `foo*.*`.
+
+Any pattern containing a forward or backward slash will be tested against the
+whole pathname and not just the module. E.g. `*/foo/bar/*=2` would change the
+logging level for all code in the source files under a `foo/bar` directory.
+
+This switch only works when `--enable-logging` is also passed.
+
+[app]: app.md
+[append-switch]: app.md#appcommandlineappendswitchswitch-value
+[ready]: app.md#event-ready
+[play-silent-audio]: https://github.com/atom/atom/pull/9485/files
+[debugging-main-process]: ../tutorial/debugging-main-process.md
+[node-cli]: https://nodejs.org/api/cli.html

--- a/test/fixtures/electron/docs/api/clipboard.md
+++ b/test/fixtures/electron/docs/api/clipboard.md
@@ -155,11 +155,11 @@ Returns `String` - Reads `data` from the clipboard.
 ### `clipboard.write(data[, type])`
 
 * `data` Object
-  * `text` String
-  * `html` String
-  * `image` [NativeImage](native-image.md)
-  * `rtf` String
-  * `bookmark` String - The title of the url at `text`.
+  * `text` String (optional)
+  * `html` String (optional)
+  * `image` [NativeImage](native-image.md) (optional)
+  * `rtf` String (optional)
+  * `bookmark` String (optional) - The title of the url at `text`.
 * `type` String (optional)
 
 ```javascript

--- a/test/fixtures/electron/docs/api/clipboard.md
+++ b/test/fixtures/electron/docs/api/clipboard.md
@@ -1,0 +1,169 @@
+# clipboard
+
+> Perform copy and paste operations on the system clipboard.
+
+Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+
+The following example shows how to write a string to the clipboard:
+
+```javascript
+const {clipboard} = require('electron')
+clipboard.writeText('Example String')
+```
+
+On X Window systems, there is also a selection clipboard. To manipulate it
+you need to pass `selection` to each method:
+
+```javascript
+const {clipboard} = require('electron')
+clipboard.writeText('Example String', 'selection')
+console.log(clipboard.readText('selection'))
+```
+
+## Methods
+
+The `clipboard` module has the following methods:
+
+**Note:** Experimental APIs are marked as such and could be removed in future.
+
+### `clipboard.readText([type])`
+
+* `type` String (optional)
+
+Returns `String` - The content in the clipboard as plain text.
+
+### `clipboard.writeText(text[, type])`
+
+* `text` String
+* `type` String (optional)
+
+Writes the `text` into the clipboard as plain text.
+
+### `clipboard.readHTML([type])`
+
+* `type` String (optional)
+
+Returns `String` - The content in the clipboard as markup.
+
+### `clipboard.writeHTML(markup[, type])`
+
+* `markup` String
+* `type` String (optional)
+
+Writes `markup` to the clipboard.
+
+### `clipboard.readImage([type])`
+
+* `type` String (optional)
+
+Returns `NativeImage` - The content in the clipboard as a [NativeImage](native-image.md).
+
+### `clipboard.writeImage(image[, type])`
+
+* `image` [NativeImage](native-image.md)
+* `type` String (optional)
+
+Writes `image` to the clipboard.
+
+### `clipboard.readRTF([type])`
+
+* `type` String (optional)
+
+Returns `String` - The content in the clipboard as RTF.
+
+### `clipboard.writeRTF(text[, type])`
+
+* `text` String
+* `type` String (optional)
+
+Writes the `text` into the clipboard in RTF.
+
+### `clipboard.readBookmark()` _macOS_ _Windows_
+
+Returns `Object`:
+
+* `title` String
+* `url` String
+
+Returns an Object containing `title` and `url` keys representing the bookmark in
+the clipboard. The `title` and `url` values will be empty strings when the
+bookmark is unavailable.
+
+### `clipboard.writeBookmark(title, url[, type])` _macOS_ _Windows_
+
+* `title` String
+* `url` String
+* `type` String (optional)
+
+Writes the `title` and `url` into the clipboard as a bookmark.
+
+**Note:** Most apps on Windows don't support pasting bookmarks into them so
+you can use `clipboard.write` to write both a bookmark and fallback text to the
+clipboard.
+
+```js
+clipboard.write({
+  text: 'http://electron.atom.io',
+  bookmark: 'Electron Homepage'
+})
+```
+
+### `clipboard.readFindText()` _macOS_
+
+Returns `String` - The text on the find pasteboard. This method uses synchronous
+IPC when called from the renderer process. The cached value is reread from the
+find pasteboard whenever the application is activated.
+
+### `clipboard.writeFindText(text)` _macOS_
+
+* `text` String
+
+Writes the `text` into the find pasteboard as plain text. This method uses
+synchronous IPC when called from the renderer process.
+
+### `clipboard.clear([type])`
+
+* `type` String (optional)
+
+Clears the clipboard content.
+
+### `clipboard.availableFormats([type])`
+
+* `type` String (optional)
+
+Returns `String[]` - An array of supported formats for the clipboard `type`.
+
+### `clipboard.has(data[, type])` _Experimental_
+
+* `data` String
+* `type` String (optional)
+
+Returns `Boolean` - Whether the clipboard supports the format of specified `data`.
+
+```javascript
+const {clipboard} = require('electron')
+console.log(clipboard.has('<p>selection</p>'))
+```
+
+### `clipboard.read(data[, type])` _Experimental_
+
+* `data` String
+* `type` String (optional)
+
+Returns `String` - Reads `data` from the clipboard.
+
+### `clipboard.write(data[, type])`
+
+* `data` Object
+  * `text` String
+  * `html` String
+  * `image` [NativeImage](native-image.md)
+  * `rtf` String
+  * `bookmark` String - The title of the url at `text`.
+* `type` String (optional)
+
+```javascript
+const {clipboard} = require('electron')
+clipboard.write({text: 'test', html: '<b>test</b>'})
+```
+Writes `data` to the clipboard.

--- a/test/fixtures/electron/docs/api/content-tracing.md
+++ b/test/fixtures/electron/docs/api/content-tracing.md
@@ -1,0 +1,171 @@
+# contentTracing
+
+> Collect tracing data from Chromium's content module for finding performance
+bottlenecks and slow operations.
+
+This module does not include a web interface so you need to open
+`chrome://tracing/` in a Chrome browser and load the generated file to view the
+result.
+
+```javascript
+const {contentTracing} = require('electron')
+
+const options = {
+  categoryFilter: '*',
+  traceOptions: 'record-until-full,enable-sampling'
+}
+
+contentTracing.startRecording(options, () => {
+  console.log('Tracing started')
+
+  setTimeout(() => {
+    contentTracing.stopRecording('', (path) => {
+      console.log('Tracing data recorded to ' + path)
+    })
+  }, 5000)
+})
+```
+
+## Methods
+
+The `contentTracing` module has the following methods:
+
+### `contentTracing.getCategories(callback)`
+
+* `callback` Function
+  * `categories` String[]
+
+Get a set of category groups. The category groups can change as new code paths
+are reached.
+
+Once all child processes have acknowledged the `getCategories` request the
+`callback` is invoked with an array of category groups.
+
+### `contentTracing.startRecording(options, callback)`
+
+* `options` Object
+  * `categoryFilter` String
+  * `traceOptions` String
+* `callback` Function
+
+Start recording on all processes.
+
+Recording begins immediately locally and asynchronously on child processes
+as soon as they receive the EnableRecording request. The `callback` will be
+called once all child processes have acknowledged the `startRecording` request.
+
+`categoryFilter` is a filter to control what category groups should be
+traced. A filter can have an optional `-` prefix to exclude category groups
+that contain a matching category. Having both included and excluded
+category patterns in the same list is not supported.
+
+Examples:
+
+* `test_MyTest*`,
+* `test_MyTest*,test_OtherStuff`,
+* `"-excluded_category1,-excluded_category2`
+
+`traceOptions` controls what kind of tracing is enabled, it is a comma-delimited
+list. Possible options are:
+
+* `record-until-full`
+* `record-continuously`
+* `trace-to-console`
+* `enable-sampling`
+* `enable-systrace`
+
+The first 3 options are trace recoding modes and hence mutually exclusive.
+If more than one trace recording modes appear in the `traceOptions` string,
+the last one takes precedence. If none of the trace recording modes are
+specified, recording mode is `record-until-full`.
+
+The trace option will first be reset to the default option (`record_mode` set to
+`record-until-full`, `enable_sampling` and `enable_systrace` set to `false`)
+before options parsed from `traceOptions` are applied on it.
+
+### `contentTracing.stopRecording(resultFilePath, callback)`
+
+* `resultFilePath` String
+* `callback` Function
+  * `resultFilePath` String
+
+Stop recording on all processes.
+
+Child processes typically cache trace data and only rarely flush and send
+trace data back to the main process. This helps to minimize the runtime overhead
+of tracing since sending trace data over IPC can be an expensive operation. So,
+to end tracing, we must asynchronously ask all child processes to flush any
+pending trace data.
+
+Once all child processes have acknowledged the `stopRecording` request,
+`callback` will be called with a file that contains the traced data.
+
+Trace data will be written into `resultFilePath` if it is not empty or into a
+temporary file. The actual file path will be passed to `callback` if it's not
+`null`.
+
+### `contentTracing.startMonitoring(options, callback)`
+
+* `options` Object
+  * `categoryFilter` String
+  * `traceOptions` String
+* `callback` Function
+
+Start monitoring on all processes.
+
+Monitoring begins immediately locally and asynchronously on child processes as
+soon as they receive the `startMonitoring` request.
+
+Once all child processes have acknowledged the `startMonitoring` request the
+`callback` will be called.
+
+### `contentTracing.stopMonitoring(callback)`
+
+* `callback` Function
+
+Stop monitoring on all processes.
+
+Once all child processes have acknowledged the `stopMonitoring` request the
+`callback` is called.
+
+### `contentTracing.captureMonitoringSnapshot(resultFilePath, callback)`
+
+* `resultFilePath` String
+* `callback` Function
+  * `resultFilePath` String
+
+Get the current monitoring traced data.
+
+Child processes typically cache trace data and only rarely flush and send
+trace data back to the main process. This is because it may be an expensive
+operation to send the trace data over IPC and we would like to avoid unneeded
+runtime overhead from tracing. So, to end tracing, we must asynchronously ask
+all child processes to flush any pending trace data.
+
+Once all child processes have acknowledged the `captureMonitoringSnapshot`
+request the `callback` will be called with a file that contains the traced data.
+
+
+### `contentTracing.getTraceBufferUsage(callback)`
+
+* `callback` Function
+  * `value` Number
+  * `percentage` Number
+
+Get the maximum usage across processes of trace buffer as a percentage of the
+full state. When the TraceBufferUsage value is determined the `callback` is
+called.
+
+### `contentTracing.setWatchEvent(categoryName, eventName, callback)`
+
+* `categoryName` String
+* `eventName` String
+* `callback` Function
+
+`callback` will be called every time the given event occurs on any
+process.
+
+### `contentTracing.cancelWatchEvent()`
+
+Cancel the watch event. This may lead to a race condition with the watch event
+callback if tracing is enabled.

--- a/test/fixtures/electron/docs/api/crash-reporter.md
+++ b/test/fixtures/electron/docs/api/crash-reporter.md
@@ -37,13 +37,13 @@ The `crash-reporter` module has the following methods:
 ### `crashReporter.start(options)`
 
 * `options` Object
-  * `companyName` String
+  * `companyName` String (optional)
   * `submitURL` String - URL that crash reports will be sent to as POST.
   * `productName` String (optional) - Defaults to `app.getName()`.
-  * `autoSubmit` Boolean - Send the crash report without user interaction.
+  * `autoSubmit` Boolean (optional) - Send the crash report without user interaction.
     Default is `true`.
-  * `ignoreSystemCrashHandler` Boolean - Default is `false`.
-  * `extra` Object - An object you can define that will be sent along with the
+  * `ignoreSystemCrashHandler` Boolean (optional) - Default is `false`.
+  * `extra` Object (optional) - An object you can define that will be sent along with the
     report. Only string properties are sent correctly, Nested objects are not
     supported.
 
@@ -58,20 +58,14 @@ crash reports.
 
 ### `crashReporter.getLastCrashReport()`
 
-Returns `Object`:
-
-* `date` String
-* `ID` Integer
+Returns [`CrashReport`](structures/crash-report.md):
 
 Returns the date and ID of the last crash report. If no crash reports have been
 sent or the crash reporter has not been started, `null` is returned.
 
 ### `crashReporter.getUploadedReports()`
 
-Returns `Object[]`:
-
-* `date` String
-* `ID` Integer
+Returns [`CrashReport[]`](structures/crash-report.md):
 
 Returns all uploaded crash reports. Each report contains the date and uploaded
 ID.

--- a/test/fixtures/electron/docs/api/crash-reporter.md
+++ b/test/fixtures/electron/docs/api/crash-reporter.md
@@ -1,0 +1,96 @@
+# crashReporter
+
+> Submit crash reports to a remote server.
+
+Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+
+The following is an example of automatically submitting a crash report to a
+remote server:
+
+```javascript
+const {crashReporter} = require('electron')
+
+crashReporter.start({
+  productName: 'YourName',
+  companyName: 'YourCompany',
+  submitURL: 'https://your-domain.com/url-to-submit',
+  autoSubmit: true
+})
+```
+
+For setting up a server to accept and process crash reports, you can use
+following projects:
+
+* [socorro](https://github.com/mozilla/socorro)
+* [mini-breakpad-server](https://github.com/electron/mini-breakpad-server)
+
+Crash reports are saved locally in an application-specific temp directory folder.
+For a `productName` of `YourName`, crash reports will be stored in a folder
+named `YourName Crashes` inside the temp directory. You can customize this temp
+directory location for your app by calling the `app.setPath('temp', '/my/custom/temp')`
+API before starting the crash reporter.
+
+## Methods
+
+The `crash-reporter` module has the following methods:
+
+### `crashReporter.start(options)`
+
+* `options` Object
+  * `companyName` String
+  * `submitURL` String - URL that crash reports will be sent to as POST.
+  * `productName` String (optional) - Defaults to `app.getName()`.
+  * `autoSubmit` Boolean - Send the crash report without user interaction.
+    Default is `true`.
+  * `ignoreSystemCrashHandler` Boolean - Default is `false`.
+  * `extra` Object - An object you can define that will be sent along with the
+    report. Only string properties are sent correctly, Nested objects are not
+    supported.
+
+You are required to call this method before using other `crashReporter`
+APIs.
+
+**Note:** On macOS, Electron uses a new `crashpad` client, which is different
+from `breakpad` on Windows and Linux. To enable the crash collection feature,
+you are required to call the `crashReporter.start` API to initialize `crashpad`
+in the main process and in each renderer process from which you wish to collect
+crash reports.
+
+### `crashReporter.getLastCrashReport()`
+
+Returns `Object`:
+
+* `date` String
+* `ID` Integer
+
+Returns the date and ID of the last crash report. If no crash reports have been
+sent or the crash reporter has not been started, `null` is returned.
+
+### `crashReporter.getUploadedReports()`
+
+Returns `Object[]`:
+
+* `date` String
+* `ID` Integer
+
+Returns all uploaded crash reports. Each report contains the date and uploaded
+ID.
+
+## crash-reporter Payload
+
+The crash reporter will send the following data to the `submitURL` as
+a `multipart/form-data` `POST`:
+
+* `ver` String - The version of Electron.
+* `platform` String - e.g. 'win32'.
+* `process_type` String - e.g. 'renderer'.
+* `guid` String - e.g. '5e1286fc-da97-479e-918b-6bfb0c3d1c72'
+* `_version` String - The version in `package.json`.
+* `_productName` String - The product name in the `crashReporter` `options`
+  object.
+* `prod` String - Name of the underlying product. In this case Electron.
+* `_companyName` String - The company name in the `crashReporter` `options`
+  object.
+* `upload_file_minidump` File - The crash report in the format of `minidump`.
+* All level one properties of the `extra` object in the `crashReporter`
+  `options` object.

--- a/test/fixtures/electron/docs/api/desktop-capturer.md
+++ b/test/fixtures/electron/docs/api/desktop-capturer.md
@@ -1,0 +1,76 @@
+# desktopCapturer
+
+> Access information about media sources that can be used to capture audio and
+> video from the desktop using the [`navigator.webkitGetUserMedia`] API.
+
+Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+
+The following example shows how to capture video from a desktop window whose
+title is `Electron`:
+
+```javascript
+// In the renderer process.
+const {desktopCapturer} = require('electron')
+
+desktopCapturer.getSources({types: ['window', 'screen']}, (error, sources) => {
+  if (error) throw error
+  for (let i = 0; i < sources.length; ++i) {
+    if (sources[i].name === 'Electron') {
+      navigator.webkitGetUserMedia({
+        audio: false,
+        video: {
+          mandatory: {
+            chromeMediaSource: 'desktop',
+            chromeMediaSourceId: sources[i].id,
+            minWidth: 1280,
+            maxWidth: 1280,
+            minHeight: 720,
+            maxHeight: 720
+          }
+        }
+      }, handleStream, handleError)
+      return
+    }
+  }
+})
+
+function handleStream (stream) {
+  document.querySelector('video').src = URL.createObjectURL(stream)
+}
+
+function handleError (e) {
+  console.log(e)
+}
+```
+
+To capture video from a source provided by `desktopCapturer` the constraints
+passed to [`navigator.webkitGetUserMedia`] must include
+`chromeMediaSource: 'desktop'`, and `audio: false`.
+
+To capture both audio and video from the entire desktop the constraints passed
+to [`navigator.webkitGetUserMedia`] must include `chromeMediaSource: 'screen'`,
+and `audio: true`, but should not include a `chromeMediaSourceId` constraint.
+
+## Methods
+
+The `desktopCapturer` module has the following methods:
+
+### `desktopCapturer.getSources(options, callback)`
+
+* `options` Object
+  * `types` String[] - An array of Strings that lists the types of desktop sources
+    to be captured, available types are `screen` and `window`.
+  * `thumbnailSize` Object (optional) - The suggested size that the media source
+    thumbnail should be scaled to, defaults to `{width: 150, height: 150}`.
+* `callback` Function
+  * `error` Error
+  * `sources` [DesktopCapturerSource[]](structures/desktop-capturer-source.md)
+
+Starts gathering information about all available desktop media sources,
+and calls `callback(error, sources)` when finished.
+
+`sources` is an array of [`DesktopCapturerSource`](structures/desktop-capturer-source.md)
+objects, each `DesktopCapturerSource` represents a screen or an individual window that can be
+captured.
+
+[`navigator.webkitGetUserMedia`]: https://developer.mozilla.org/en/docs/Web/API/Navigator/getUserMedia

--- a/test/fixtures/electron/docs/api/dialog.md
+++ b/test/fixtures/electron/docs/api/dialog.md
@@ -27,19 +27,19 @@ The `dialog` module has the following methods:
 
 * `browserWindow` BrowserWindow (optional)
 * `options` Object
-  * `title` String
-  * `defaultPath` String
-  * `buttonLabel` String - Custom label for the confirmation button, when
+  * `title` String (optional)
+  * `defaultPath` String (optional)
+  * `buttonLabel` String (optional) - Custom label for the confirmation button, when
     left empty the default label will be used.
-  * `filters` String[]
-  * `properties` String[] - Contains which features the dialog should use, can
+  * `filters` [FileFilter[]](structrs/file-filter.md) (optional)
+  * `properties` String[] (optional) - Contains which features the dialog should use, can
     contain `openFile`, `openDirectory`, `multiSelections`, `createDirectory`
     and `showHiddenFiles`.
 * `callback` Function (optional)
   * `filePaths` String[] - An array of file paths chosen by the user
 
-On success this method returns an array of file paths chosen by the user,
-otherwise it returns `undefined`.
+Returns `String[]`, an array of file paths chosen by the user,
+if the callback is provided it returns `undefined`.
 
 The `filters` specifies an array of file types that can be displayed or
 selected when you want to limit the user to a specific type. For example:
@@ -71,16 +71,16 @@ shown.
 
 * `browserWindow` BrowserWindow (optional)
 * `options` Object
-  * `title` String
-  * `defaultPath` String
-  * `buttonLabel` String - Custom label for the confirmation button, when
+  * `title` String (optional)
+  * `defaultPath` String (optional)
+  * `buttonLabel` String (optional) - Custom label for the confirmation button, when
     left empty the default label will be used.
-  * `filters` String[]
+  * `filters` [FileFilter[]](structrs/file-filter.md) (optional)
 * `callback` Function (optional)
   * `filename` String
 
-On success this method returns the path of the file chosen by the user,
-otherwise it returns `undefined`.
+Returns `String`, the path of the file chosen by the user,
+if a callback is provided it returns `undefined`.
 
 The `filters` specifies an array of file types that can be displayed, see
 `dialog.showOpenDialog` for an example.
@@ -92,29 +92,32 @@ will be passed via `callback(filename)`
 
 * `browserWindow` BrowserWindow (optional)
 * `options` Object
-  * `type` String - Can be `"none"`, `"info"`, `"error"`, `"question"` or
+  * `type` String (optional) - Can be `"none"`, `"info"`, `"error"`, `"question"` or
   `"warning"`. On Windows, "question" displays the same icon as "info", unless
   you set an icon using the "icon" option.
-  * `buttons` String[] - Array of texts for buttons. On Windows, an empty array
+  * `buttons` String[] (optional) - Array of texts for buttons. On Windows, an empty array
     will result in one button labeled "OK".
-  * `defaultId` Integer - Index of the button in the buttons array which will
+  * `defaultId` Integer (optional) - Index of the button in the buttons array which will
     be selected by default when the message box opens.
-  * `title` String - Title of the message box, some platforms will not show it.
+  * `title` String (optional) - Title of the message box, some platforms will not show it.
   * `message` String - Content of the message box.
-  * `detail` String - Extra information of the message.
-  * `icon` [NativeImage](native-image.md)
-  * `cancelId` Integer - The value will be returned when user cancels the dialog
+  * `detail` String (optional) - Extra information of the message.
+  * `icon` [NativeImage](native-image.md) (optional)
+  * `cancelId` Integer (optional) - The value will be returned when user cancels the dialog
     instead of clicking the buttons of the dialog. By default it is the index
     of the buttons that have "cancel" or "no" as label, or 0 if there is no such
     buttons. On macOS and Windows the index of "Cancel" button will always be
     used as `cancelId`, not matter whether it is already specified.
-  * `noLink` Boolean - On Windows Electron will try to figure out which one of
+  * `noLink` Boolean (optional) - On Windows Electron will try to figure out which one of
     the `buttons` are common buttons (like "Cancel" or "Yes"), and show the
     others as command links in the dialog. This can make the dialog appear in
     the style of modern Windows apps. If you don't like this behavior, you can
     set `noLink` to `true`.
-* `callback` Function
+* `callback` Function (optional)
   * `response` Number - The index of the button that was clicked
+
+Returns `Integer`, the index of the clicked button, if a callback is provided
+it returns undefined.
 
 Shows a message box, it will block the process until the message box is closed.
 It returns the index of the clicked button.

--- a/test/fixtures/electron/docs/api/dialog.md
+++ b/test/fixtures/electron/docs/api/dialog.md
@@ -1,0 +1,144 @@
+# dialog
+
+> Display native system dialogs for opening and saving files, alerting, etc.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+An example of showing a dialog to select multiple files and directories:
+
+```javascript
+const {dialog} = require('electron')
+console.log(dialog.showOpenDialog({properties: ['openFile', 'openDirectory', 'multiSelections']}))
+```
+
+The Dialog is opened from Electron's main thread. If you want to use the dialog
+object from a renderer process, remember to access it using the remote:
+
+```javascript
+const {dialog} = require('electron').remote
+console.log(dialog)
+```
+
+## Methods
+
+The `dialog` module has the following methods:
+
+### `dialog.showOpenDialog([browserWindow, ]options[, callback])`
+
+* `browserWindow` BrowserWindow (optional)
+* `options` Object
+  * `title` String
+  * `defaultPath` String
+  * `buttonLabel` String - Custom label for the confirmation button, when
+    left empty the default label will be used.
+  * `filters` String[]
+  * `properties` String[] - Contains which features the dialog should use, can
+    contain `openFile`, `openDirectory`, `multiSelections`, `createDirectory`
+    and `showHiddenFiles`.
+* `callback` Function (optional)
+  * `filePaths` String[] - An array of file paths chosen by the user
+
+On success this method returns an array of file paths chosen by the user,
+otherwise it returns `undefined`.
+
+The `filters` specifies an array of file types that can be displayed or
+selected when you want to limit the user to a specific type. For example:
+
+```javascript
+{
+  filters: [
+    {name: 'Images', extensions: ['jpg', 'png', 'gif']},
+    {name: 'Movies', extensions: ['mkv', 'avi', 'mp4']},
+    {name: 'Custom File Type', extensions: ['as']},
+    {name: 'All Files', extensions: ['*']}
+  ]
+}
+```
+
+The `extensions` array should contain extensions without wildcards or dots (e.g.
+`'png'` is good but `'.png'` and `'*.png'` are bad). To show all files, use the
+`'*'` wildcard (no other wildcard is supported).
+
+If a `callback` is passed, the API call will be asynchronous and the result
+will be passed via `callback(filenames)`
+
+**Note:** On Windows and Linux an open dialog can not be both a file selector
+and a directory selector, so if you set `properties` to
+`['openFile', 'openDirectory']` on these platforms, a directory selector will be
+shown.
+
+### `dialog.showSaveDialog([browserWindow, ]options[, callback])`
+
+* `browserWindow` BrowserWindow (optional)
+* `options` Object
+  * `title` String
+  * `defaultPath` String
+  * `buttonLabel` String - Custom label for the confirmation button, when
+    left empty the default label will be used.
+  * `filters` String[]
+* `callback` Function (optional)
+  * `filename` String
+
+On success this method returns the path of the file chosen by the user,
+otherwise it returns `undefined`.
+
+The `filters` specifies an array of file types that can be displayed, see
+`dialog.showOpenDialog` for an example.
+
+If a `callback` is passed, the API call will be asynchronous and the result
+will be passed via `callback(filename)`
+
+### `dialog.showMessageBox([browserWindow, ]options[, callback])`
+
+* `browserWindow` BrowserWindow (optional)
+* `options` Object
+  * `type` String - Can be `"none"`, `"info"`, `"error"`, `"question"` or
+  `"warning"`. On Windows, "question" displays the same icon as "info", unless
+  you set an icon using the "icon" option.
+  * `buttons` String[] - Array of texts for buttons. On Windows, an empty array
+    will result in one button labeled "OK".
+  * `defaultId` Integer - Index of the button in the buttons array which will
+    be selected by default when the message box opens.
+  * `title` String - Title of the message box, some platforms will not show it.
+  * `message` String - Content of the message box.
+  * `detail` String - Extra information of the message.
+  * `icon` [NativeImage](native-image.md)
+  * `cancelId` Integer - The value will be returned when user cancels the dialog
+    instead of clicking the buttons of the dialog. By default it is the index
+    of the buttons that have "cancel" or "no" as label, or 0 if there is no such
+    buttons. On macOS and Windows the index of "Cancel" button will always be
+    used as `cancelId`, not matter whether it is already specified.
+  * `noLink` Boolean - On Windows Electron will try to figure out which one of
+    the `buttons` are common buttons (like "Cancel" or "Yes"), and show the
+    others as command links in the dialog. This can make the dialog appear in
+    the style of modern Windows apps. If you don't like this behavior, you can
+    set `noLink` to `true`.
+* `callback` Function
+  * `response` Number - The index of the button that was clicked
+
+Shows a message box, it will block the process until the message box is closed.
+It returns the index of the clicked button.
+
+If a `callback` is passed, the API call will be asynchronous and the result
+will be passed via `callback(response)`.
+
+### `dialog.showErrorBox(title, content)`
+
+* `title` String - The title to display in the error box
+* `content` String - The text content to display in the error box
+
+Displays a modal dialog that shows an error message.
+
+This API can be called safely before the `ready` event the `app` module emits,
+it is usually used to report errors in early stage of startup.  If called
+before the app `ready`event on Linux, the message will be emitted to stderr,
+and no GUI dialog will appear.
+
+## Sheets
+
+On macOS, dialogs are presented as sheets attached to a window if you provide
+a `BrowserWindow` reference in the `browserWindow` parameter, or modals if no
+window is provided.
+
+You can call `BrowserWindow.getCurrentWindow().setSheetOffset(offset)` to change
+the offset from the window frame where sheets are attached.

--- a/test/fixtures/electron/docs/api/download-item.md
+++ b/test/fixtures/electron/docs/api/download-item.md
@@ -37,9 +37,11 @@ win.webContents.session.on('will-download', (event, item, webContents) => {
 })
 ```
 
-## Events
+## Class: DownloadItem
 
-### Event: 'updated'
+### Instance Events
+
+#### Event: 'updated'
 
 Returns:
 
@@ -53,7 +55,7 @@ The `state` can be one of following:
 * `progressing` - The download is in-progress.
 * `interrupted` - The download has interrupted and can be resumed.
 
-### Event: 'done'
+#### Event: 'done'
 
 Returns:
 
@@ -70,11 +72,11 @@ The `state` can be one of following:
 * `cancelled` - The download has been cancelled.
 * `interrupted` - The download has interrupted and can not resume.
 
-## Methods
+### Instance Methods
 
 The `downloadItem` object has the following methods:
 
-### `downloadItem.setSavePath(path)`
+#### `downloadItem.setSavePath(path)`
 
 * `path` String - Set the save file path of the download item.
 
@@ -82,45 +84,45 @@ The API is only available in session's `will-download` callback function.
 If user doesn't set the save path via the API, Electron will use the original
 routine to determine the save path(Usually prompts a save dialog).
 
-### `downloadItem.getSavePath()`
+#### `downloadItem.getSavePath()`
 
 Returns `String` - The save path of the download item. This will be either the path
 set via `downloadItem.setSavePath(path)` or the path selected from the shown
 save dialog.
 
-### `downloadItem.pause()`
+#### `downloadItem.pause()`
 
 Pauses the download.
 
-### `downloadItem.isPaused()`
+#### `downloadItem.isPaused()`
 
 Returns `Boolean` - Whether the download is paused.
 
-### `downloadItem.resume()`
+#### `downloadItem.resume()`
 
 Resumes the download that has been paused.
 
-### `downloadItem.canResume()`
+#### `downloadItem.canResume()`
 
 Resumes `Boolean` - Whether the download can resume.
 
-### `downloadItem.cancel()`
+#### `downloadItem.cancel()`
 
 Cancels the download operation.
 
-### `downloadItem.getURL()`
+#### `downloadItem.getURL()`
 
 Returns `String` - The origin url where the item is downloaded from.
 
-### `downloadItem.getMimeType()`
+#### `downloadItem.getMimeType()`
 
 Returns `String` - The files mime type.
 
-### `downloadItem.hasUserGesture()`
+#### `downloadItem.hasUserGesture()`
 
 Returns `Boolean` - Whether the download has user gesture.
 
-### `downloadItem.getFilename()`
+#### `downloadItem.getFilename()`
 
 Returns `String` - The file name of the download item.
 
@@ -128,28 +130,21 @@ Returns `String` - The file name of the download item.
 disk. If user changes the file name in a prompted download saving dialog, the
 actual name of saved file will be different.
 
-### `downloadItem.getTotalBytes()`
+#### `downloadItem.getTotalBytes()`
 
 Returns `Integer` - The total size in bytes of the download item.
 
 If the size is unknown, it returns 0.
 
-### `downloadItem.getReceivedBytes()`
+#### `downloadItem.getReceivedBytes()`
 
 Returns `Integer` - The received bytes of the download item.
 
-### `downloadItem.getContentDisposition()`
+#### `downloadItem.getContentDisposition()`
 
 Returns `String` - The Content-Disposition field from the response
 header.
 
-### `downloadItem.getState()`
+#### `downloadItem.getState()`
 
-Returns `String` - The current state.
-
-Possible values are:
-
-* `progressing` - The download is in-progress.
-* `completed` - The download completed successfully.
-* `cancelled` - The download has been cancelled.
-* `interrupted` - The download has interrupted.
+Returns `String` - The current state.  Can be `progressing`, `completed`, `cancelled` or `interrupted`.

--- a/test/fixtures/electron/docs/api/download-item.md
+++ b/test/fixtures/electron/docs/api/download-item.md
@@ -1,0 +1,155 @@
+# DownloadItem
+
+> Control file downloads from remote sources.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+`DownloadItem` is an `EventEmitter` that represents a download item in Electron.
+It is used in `will-download` event of `Session` class, and allows users to
+control the download item.
+
+```javascript
+// In the main process.
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow()
+win.webContents.session.on('will-download', (event, item, webContents) => {
+  // Set the save path, making Electron not to prompt a save dialog.
+  item.setSavePath('/tmp/save.pdf')
+
+  item.on('updated', (event, state) => {
+    if (state === 'interrupted') {
+      console.log('Download is interrupted but can be resumed')
+    } else if (state === 'progressing') {
+      if (item.isPaused()) {
+        console.log('Download is paused')
+      } else {
+        console.log(`Received bytes: ${item.getReceivedBytes()}`)
+      }
+    }
+  })
+  item.once('done', (event, state) => {
+    if (state === 'completed') {
+      console.log('Download successfully')
+    } else {
+      console.log(`Download failed: ${state}`)
+    }
+  })
+})
+```
+
+## Events
+
+### Event: 'updated'
+
+Returns:
+
+* `event` Event
+* `state` String
+
+Emitted when the download has been updated and is not done.
+
+The `state` can be one of following:
+
+* `progressing` - The download is in-progress.
+* `interrupted` - The download has interrupted and can be resumed.
+
+### Event: 'done'
+
+Returns:
+
+* `event` Event
+* `state` String
+
+Emitted when the download is in a terminal state. This includes a completed
+download, a cancelled download (via `downloadItem.cancel()`), and interrupted
+download that can't be resumed.
+
+The `state` can be one of following:
+
+* `completed` - The download completed successfully.
+* `cancelled` - The download has been cancelled.
+* `interrupted` - The download has interrupted and can not resume.
+
+## Methods
+
+The `downloadItem` object has the following methods:
+
+### `downloadItem.setSavePath(path)`
+
+* `path` String - Set the save file path of the download item.
+
+The API is only available in session's `will-download` callback function.
+If user doesn't set the save path via the API, Electron will use the original
+routine to determine the save path(Usually prompts a save dialog).
+
+### `downloadItem.getSavePath()`
+
+Returns `String` - The save path of the download item. This will be either the path
+set via `downloadItem.setSavePath(path)` or the path selected from the shown
+save dialog.
+
+### `downloadItem.pause()`
+
+Pauses the download.
+
+### `downloadItem.isPaused()`
+
+Returns `Boolean` - Whether the download is paused.
+
+### `downloadItem.resume()`
+
+Resumes the download that has been paused.
+
+### `downloadItem.canResume()`
+
+Resumes `Boolean` - Whether the download can resume.
+
+### `downloadItem.cancel()`
+
+Cancels the download operation.
+
+### `downloadItem.getURL()`
+
+Returns `String` - The origin url where the item is downloaded from.
+
+### `downloadItem.getMimeType()`
+
+Returns `String` - The files mime type.
+
+### `downloadItem.hasUserGesture()`
+
+Returns `Boolean` - Whether the download has user gesture.
+
+### `downloadItem.getFilename()`
+
+Returns `String` - The file name of the download item.
+
+**Note:** The file name is not always the same as the actual one saved in local
+disk. If user changes the file name in a prompted download saving dialog, the
+actual name of saved file will be different.
+
+### `downloadItem.getTotalBytes()`
+
+Returns `Integer` - The total size in bytes of the download item.
+
+If the size is unknown, it returns 0.
+
+### `downloadItem.getReceivedBytes()`
+
+Returns `Integer` - The received bytes of the download item.
+
+### `downloadItem.getContentDisposition()`
+
+Returns `String` - The Content-Disposition field from the response
+header.
+
+### `downloadItem.getState()`
+
+Returns `String` - The current state.
+
+Possible values are:
+
+* `progressing` - The download is in-progress.
+* `completed` - The download completed successfully.
+* `cancelled` - The download has been cancelled.
+* `interrupted` - The download has interrupted.

--- a/test/fixtures/electron/docs/api/environment-variables.md
+++ b/test/fixtures/electron/docs/api/environment-variables.md
@@ -1,0 +1,86 @@
+# Environment Variables
+
+> Control application configuration and behavior without changing code.
+
+Certain Electron behaviors are controlled by environment variables because they
+are initialized earlier than the command line flags and the app's code.
+
+POSIX shell example:
+
+```bash
+$ export ELECTRON_ENABLE_LOGGING=true
+$ electron
+```
+
+Windows console example:
+
+```powershell
+> set ELECTRON_ENABLE_LOGGING=true
+> electron
+```
+
+## Production Variables
+
+The following environment variables are intended primarily for use at runtime
+in packaged Electron applications.
+
+### `GOOGLE_API_KEY`
+
+Electron includes a hardcoded API key for making requests to Google's geocoding
+webservice. Because this API key is included in every version of Electron, it
+often exceeds its usage quota. To work around this, you can supply your own
+Google API key in the environment. Place the following code in your main process
+file, before opening any browser windows that will make geocoding requests:
+
+```javascript
+process.env.GOOGLE_API_KEY = 'YOUR_KEY_HERE'
+```
+
+For instructions on how to acquire a Google API key, visit [this page](https://www.chromium.org/developers/how-tos/api-keys).
+
+By default, a newly generated Google API key may not be allowed to make
+geocoding requests. To enable geocoding requests, visit [this page](https://console.developers.google.com/apis/api/geolocation/overview).
+
+### `ELECTRON_NO_ASAR`
+
+Disables ASAR support. This variable is only supported in forked child processes
+and spawned child processes that set `ELECTRON_RUN_AS_NODE`.
+
+## Development Variables
+
+The following environment variables are intended primarily for development and
+debugging purposes.
+
+### `ELECTRON_RUN_AS_NODE`
+
+Starts the process as a normal Node.js process.
+
+### `ELECTRON_ENABLE_LOGGING`
+
+Prints Chrome's internal logging to the console.
+
+### `ELECTRON_LOG_ASAR_READS`
+
+When Electron reads from an ASAR file, log the read offset and file path to
+the system `tmpdir`. The resulting file can be provided to the ASAR module
+to optimize file ordering.
+
+### `ELECTRON_ENABLE_STACK_DUMPING`
+
+Prints the stack trace to the console when Electron crashes.
+
+This environment variable will not work if the `crashReporter` is started.
+
+### `ELECTRON_DEFAULT_ERROR_MODE` _Windows_
+
+Shows the Windows's crash dialog when Electron crashes.
+
+This environment variable will not work if the `crashReporter` is started.
+
+### `ELECTRON_NO_ATTACH_CONSOLE` _Windows_
+
+Don't attach to the current console session.
+
+### `ELECTRON_FORCE_WINDOW_MENU_BAR` _Linux_
+
+Don't use the global menu bar on Linux.

--- a/test/fixtures/electron/docs/api/file-object.md
+++ b/test/fixtures/electron/docs/api/file-object.md
@@ -1,0 +1,33 @@
+# `File` Object
+
+> Use the HTML5 `File` API to work natively with files on the filesystem.
+
+The DOM's File interface provides abstraction around native files in order to
+let users work on native files directly with the HTML5 file API. Electron has
+added a `path` attribute to the `File` interface which exposes the file's real
+path on filesystem.
+
+Example of getting a real path from a dragged-onto-the-app file:
+
+```html
+<div id="holder">
+  Drag your file here
+</div>
+
+<script>
+  const holder = document.getElementById('holder')
+  holder.ondragover = () => {
+    return false;
+  }
+  holder.ondragleave = holder.ondragend = () => {
+    return false;
+  }
+  holder.ondrop = (e) => {
+    e.preventDefault()
+    for (let f of e.dataTransfer.files) {
+      console.log('File(s) you dragged here: ', f.path)
+    }
+    return false;
+  }
+</script>
+```

--- a/test/fixtures/electron/docs/api/frameless-window.md
+++ b/test/fixtures/electron/docs/api/frameless-window.md
@@ -1,0 +1,143 @@
+# Frameless Window
+
+> Open a window without toolbars, borders, or other graphical "chrome".
+
+A frameless window is a window that has no
+[chrome](https://developer.mozilla.org/en-US/docs/Glossary/Chrome), the parts of
+the window, like toolbars, that are not a part of the web page. These are
+options on the [`BrowserWindow`](browser-window.md) class.
+
+## Create a frameless window
+
+To create a frameless window, you need to set `frame` to `false` in
+[BrowserWindow](browser-window.md)'s `options`:
+
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow({width: 800, height: 600, frame: false})
+win.show()
+```
+
+### Alternatives on macOS
+
+On macOS 10.9 Mavericks and newer, there's an alternative way to specify
+a chromeless window. Instead of setting `frame` to `false` which disables
+both the titlebar and window controls, you may want to have the title bar
+hidden and your content extend to the full window size, yet still preserve
+the window controls ("traffic lights") for standard window actions.
+You can do so by specifying the new `titleBarStyle` option:
+
+#### `hidden`
+
+Results in a hidden title bar and a full size content window, yet the title bar still has the standard window controls (“traffic lights”) in the top left.
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow({titleBarStyle: 'hidden'})
+win.show()
+```
+
+#### `hidden-inset`
+
+Results in a hidden title bar with an alternative look where the traffic light buttons are slightly more inset from the window edge.
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow({titleBarStyle: 'hidden-inset'})
+win.show()
+```
+
+## Transparent window
+
+By setting the `transparent` option to `true`, you can also make the frameless
+window transparent:
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow({transparent: true, frame: false})
+win.show()
+```
+
+### Limitations
+
+* You can not click through the transparent area. We are going to introduce an
+  API to set window shape to solve this, see
+  [our issue](https://github.com/electron/electron/issues/1335) for details.
+* Transparent windows are not resizable. Setting `resizable` to `true` may make
+  a transparent window stop working on some platforms.
+* The `blur` filter only applies to the web page, so there is no way to apply
+  blur effect to the content below the window (i.e. other applications open on
+  the user's system).
+* On Windows operating systems, transparent windows will not work when DWM is
+  disabled.
+* On Linux users have to put `--enable-transparent-visuals --disable-gpu` in
+  the command line to disable GPU and allow ARGB to make transparent window,
+  this is caused by an upstream bug that [alpha channel doesn't work on some
+  NVidia drivers](https://code.google.com/p/chromium/issues/detail?id=369209) on
+  Linux.
+* On Mac the native window shadow will not be shown on a transparent window.
+
+## Click-through window
+
+To create a click-through window, i.e. making the window ignore all mouse
+events, you can call the [win.setIgnoreMouseEvents(ignore)][ignore-mouse-events]
+API:
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow()
+win.setIgnoreMouseEvents(true)
+```
+
+## Draggable region
+
+By default, the frameless window is non-draggable. Apps need to specify
+`-webkit-app-region: drag` in CSS to tell Electron which regions are draggable
+(like the OS's standard titlebar), and apps can also use
+`-webkit-app-region: no-drag` to exclude the non-draggable area from the
+ draggable region. Note that only rectangular shapes are currently supported.
+
+To make the whole window draggable, you can add `-webkit-app-region: drag` as
+`body`'s style:
+
+```html
+<body style="-webkit-app-region: drag">
+</body>
+```
+
+And note that if you have made the whole window draggable, you must also mark
+buttons as non-draggable, otherwise it would be impossible for users to click on
+them:
+
+```css
+button {
+  -webkit-app-region: no-drag;
+}
+```
+
+If you're setting just a custom titlebar as draggable, you also need to make all
+buttons in titlebar non-draggable.
+
+## Text selection
+
+In a frameless window the dragging behaviour may conflict with selecting text.
+For example, when you drag the titlebar you may accidentally select the text on
+the titlebar. To prevent this, you need to disable text selection within a
+draggable area like this:
+
+```css
+.titlebar {
+  -webkit-user-select: none;
+  -webkit-app-region: drag;
+}
+```
+
+## Context menu
+
+On some platforms, the draggable area will be treated as a non-client frame, so
+when you right click on it a system menu will pop up. To make the context menu
+behave correctly on all platforms you should never use a custom context menu on
+draggable areas.
+
+[ignore-mouse-events]: browser-window.md#winsetignoremouseeventsignore

--- a/test/fixtures/electron/docs/api/global-shortcut.md
+++ b/test/fixtures/electron/docs/api/global-shortcut.md
@@ -1,0 +1,75 @@
+# globalShortcut
+
+> Detect keyboard events when the application does not have keyboard focus.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+The `globalShortcut` module can register/unregister a global keyboard shortcut
+with the operating system so that you can customize the operations for various
+shortcuts.
+
+**Note:** The shortcut is global; it will work even if the app does
+not have the keyboard focus. You should not use this module until the `ready`
+event of the app module is emitted.
+
+```javascript
+const {app, globalShortcut} = require('electron')
+
+app.on('ready', () => {
+  // Register a 'CommandOrControl+X' shortcut listener.
+  const ret = globalShortcut.register('CommandOrControl+X', () => {
+    console.log('CommandOrControl+X is pressed')
+  })
+
+  if (!ret) {
+    console.log('registration failed')
+  }
+
+  // Check whether a shortcut is registered.
+  console.log(globalShortcut.isRegistered('CommandOrControl+X'))
+})
+
+app.on('will-quit', () => {
+  // Unregister a shortcut.
+  globalShortcut.unregister('CommandOrControl+X')
+
+  // Unregister all shortcuts.
+  globalShortcut.unregisterAll()
+})
+```
+
+## Methods
+
+The `globalShortcut` module has the following methods:
+
+### `globalShortcut.register(accelerator, callback)`
+
+* `accelerator` [Accelerator](accelerator.md)
+* `callback` Function
+
+Registers a global shortcut of `accelerator`. The `callback` is called when
+the registered shortcut is pressed by the user.
+
+When the accelerator is already taken by other applications, this call will
+silently fail. This behavior is intended by operating systems, since they don't
+want applications to fight for global shortcuts.
+
+### `globalShortcut.isRegistered(accelerator)`
+
+* `accelerator` [Accelerator](accelerator.md)
+
+Returns `Boolean` - Whether this application has registered `accelerator`.
+
+When the accelerator is already taken by other applications, this call will
+still return `false`. This behavior is intended by operating systems, since they
+don't want applications to fight for global shortcuts.
+
+### `globalShortcut.unregister(accelerator)`
+
+* `accelerator` [Accelerator](accelerator.md)
+
+Unregisters the global shortcut of `accelerator`.
+
+### `globalShortcut.unregisterAll()`
+
+Unregisters all of the global shortcuts.

--- a/test/fixtures/electron/docs/api/ipc-main.md
+++ b/test/fixtures/electron/docs/api/ipc-main.md
@@ -1,0 +1,99 @@
+# ipcMain
+
+> Communicate asynchronously from the main process to renderer processes.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+The `ipcMain` module is an instance of the
+[EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) class. When used in the main
+process, it handles asynchronous and synchronous messages sent from a renderer
+process (web page). Messages sent from a renderer will be emitted to this
+module.
+
+## Sending Messages
+
+It is also possible to send messages from the main process to the renderer
+process, see [webContents.send][web-contents-send] for more information.
+
+* When sending a message, the event name is the `channel`.
+* To reply a synchronous message, you need to set `event.returnValue`.
+* To send an asynchronous back to the sender, you can use
+  `event.sender.send(...)`.
+
+An example of sending and handling messages between the render and main
+processes:
+
+```javascript
+// In main process.
+const {ipcMain} = require('electron')
+ipcMain.on('asynchronous-message', (event, arg) => {
+  console.log(arg)  // prints "ping"
+  event.sender.send('asynchronous-reply', 'pong')
+})
+
+ipcMain.on('synchronous-message', (event, arg) => {
+  console.log(arg)  // prints "ping"
+  event.returnValue = 'pong'
+})
+```
+
+```javascript
+// In renderer process (web page).
+const {ipcRenderer} = require('electron')
+console.log(ipcRenderer.sendSync('synchronous-message', 'ping')) // prints "pong"
+
+ipcRenderer.on('asynchronous-reply', (event, arg) => {
+  console.log(arg) // prints "pong"
+})
+ipcRenderer.send('asynchronous-message', 'ping')
+```
+
+## Methods
+
+The `ipcMain` module has the following method to listen for events:
+
+### `ipcMain.on(channel, listener)`
+
+* `channel` String
+* `listener` Function
+
+Listens to `channel`, when a new message arrives `listener` would be called with
+`listener(event, args...)`.
+
+### `ipcMain.once(channel, listener)`
+
+* `channel` String
+* `listener` Function
+
+Adds a one time `listener` function for the event. This `listener` is invoked
+only the next time a message is sent to `channel`, after which it is removed.
+
+### `ipcMain.removeListener(channel, listener)`
+
+* `channel` String
+* `listener` Function
+
+Removes the specified `listener` from the listener array for the specified
+`channel`.
+
+### `ipcMain.removeAllListeners([channel])`
+
+* `channel` String (optional)
+
+Removes all listeners, or those of the specified `channel`.
+
+## Event object
+
+The `event` object passed to the `callback` has the following methods:
+
+### `event.returnValue`
+
+Set this to the value to be returned in a synchronous message.
+
+### `event.sender`
+
+Returns the `webContents` that sent the message, you can call
+`event.sender.send` to reply to the asynchronous message, see
+[webContents.send][web-contents-send] for more information.
+
+[web-contents-send]: web-contents.md#webcontentssendchannel-arg1-arg2-

--- a/test/fixtures/electron/docs/api/ipc-renderer.md
+++ b/test/fixtures/electron/docs/api/ipc-renderer.md
@@ -14,7 +14,7 @@ See [ipcMain](ipc-main.md) for code examples.
 
 ## Methods
 
-The `ipcRenderer` module has the following method to listen for events:
+The `ipcRenderer` module has the following method to listen for events and send messages:
 
 ### `ipcRenderer.on(channel, listener)`
 
@@ -46,14 +46,10 @@ Removes the specified `listener` from the listener array for the specified
 
 Removes all listeners, or those of the specified `channel`.
 
-## Sending Messages
-
-The `ipcRenderer` module has the following methods for sending messages:
-
 ### `ipcRenderer.send(channel[, arg1][, arg2][, ...])`
 
 * `channel` String
-* `arg` (optional)
+* `...args` any[]
 
 Send a message to the main process asynchronously via `channel`, you can also
 send arbitrary arguments. Arguments will be serialized in JSON internally and
@@ -64,7 +60,7 @@ The main process handles it by listening for `channel` with `ipcMain` module.
 ### `ipcRenderer.sendSync(channel[, arg1][, arg2][, ...])`
 
 * `channel` String
-* `arg` (optional)
+* `...args` any[]
 
 Send a message to the main process synchronously via `channel`, you can also
 send arbitrary arguments. Arguments will be serialized in JSON internally and
@@ -79,7 +75,7 @@ unless you know what you are doing you should never use it.
 ### `ipcRenderer.sendToHost(channel[, arg1][, arg2][, ...])`
 
 * `channel` String
-* `arg` (optional)
+* `...args` any[]
 
 Like `ipcRenderer.send` but the event will be sent to the `<webview>` element in
 the host page instead of the main process.

--- a/test/fixtures/electron/docs/api/ipc-renderer.md
+++ b/test/fixtures/electron/docs/api/ipc-renderer.md
@@ -1,0 +1,85 @@
+# ipcRenderer
+
+> Communicate asynchronously from a renderer process to the main process.
+
+Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+
+The `ipcRenderer` module is an instance of the
+[EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) class. It provides a few
+methods so you can send synchronous and asynchronous messages from the render
+process (web page) to the main process.  You can also receive replies from the
+main process.
+
+See [ipcMain](ipc-main.md) for code examples.
+
+## Methods
+
+The `ipcRenderer` module has the following method to listen for events:
+
+### `ipcRenderer.on(channel, listener)`
+
+* `channel` String
+* `listener` Function
+
+Listens to `channel`, when a new message arrives `listener` would be called with
+`listener(event, args...)`.
+
+### `ipcRenderer.once(channel, listener)`
+
+* `channel` String
+* `listener` Function
+
+Adds a one time `listener` function for the event. This `listener` is invoked
+only the next time a message is sent to `channel`, after which it is removed.
+
+### `ipcRenderer.removeListener(channel, listener)`
+
+* `channel` String
+* `listener` Function
+
+Removes the specified `listener` from the listener array for the specified
+`channel`.
+
+### `ipcRenderer.removeAllListeners([channel])`
+
+* `channel` String (optional)
+
+Removes all listeners, or those of the specified `channel`.
+
+## Sending Messages
+
+The `ipcRenderer` module has the following methods for sending messages:
+
+### `ipcRenderer.send(channel[, arg1][, arg2][, ...])`
+
+* `channel` String
+* `arg` (optional)
+
+Send a message to the main process asynchronously via `channel`, you can also
+send arbitrary arguments. Arguments will be serialized in JSON internally and
+hence no functions or prototype chain will be included.
+
+The main process handles it by listening for `channel` with `ipcMain` module.
+
+### `ipcRenderer.sendSync(channel[, arg1][, arg2][, ...])`
+
+* `channel` String
+* `arg` (optional)
+
+Send a message to the main process synchronously via `channel`, you can also
+send arbitrary arguments. Arguments will be serialized in JSON internally and
+hence no functions or prototype chain will be included.
+
+The main process handles it by listening for `channel` with `ipcMain` module,
+and replies by setting `event.returnValue`.
+
+**Note:** Sending a synchronous message will block the whole renderer process,
+unless you know what you are doing you should never use it.
+
+### `ipcRenderer.sendToHost(channel[, arg1][, arg2][, ...])`
+
+* `channel` String
+* `arg` (optional)
+
+Like `ipcRenderer.send` but the event will be sent to the `<webview>` element in
+the host page instead of the main process.

--- a/test/fixtures/electron/docs/api/locales.md
+++ b/test/fixtures/electron/docs/api/locales.md
@@ -1,0 +1,139 @@
+# Locales
+
+> Locale values returned by `app.getLocale()`.
+
+Electron uses Chromium's `l10n_util` library to fetch the locale. Possible
+values are listed below:
+
+| Language Code | Language Name |
+|---------------|---------------|
+| af | Afrikaans |
+| ar-AE | Arabic (U.A.E.) |
+| ar-IQ | Arabic (Iraq) |
+| ar | Arabic (Standard) |
+| ar-BH | Arabic (Bahrain) |
+| ar-DZ | Arabic (Algeria) |
+| ar-EG | Arabic (Egypt) |
+| ar | Aragonese |
+| ar-JO | Arabic (Jordan) |
+| ar-KW | Arabic (Kuwait) |
+| ar-LB | Arabic (Lebanon) |
+| ar-LY | Arabic (Libya) |
+| ar-MA | Arabic (Morocco) |
+| ar-OM | Arabic (Oman) |
+| ar-QA | Arabic (Qatar) |
+| ar-SA | Arabic (Saudi Arabia) |
+| ar-SY | Arabic (Syria) |
+| ar-TN | Arabic (Tunisia) |
+| ar-YE | Arabic (Yemen) |
+| as | Assamese |
+| ast | Asturian |
+| az | Azerbaijani |
+| be | Belarusian |
+| bg | Bulgarian |
+| bg | Bulgarian |
+| bn | Bengali |
+| br | Breton |
+| bs | Bosnian |
+| ca | Catalan |
+| ce | Chechen |
+| ch | Chamorro |
+| co | Corsican |
+| cr | Cree |
+| cs | Czech |
+| cv | Chuvash |
+| da | Danish |
+| de | German (Standard) |
+| de-AT | German (Austria) |
+| de-CH | German (Switzerland) |
+| de-DE | German (Germany) |
+| de-LI | German (Liechtenstein) |
+| de-LU | German (Luxembourg) |
+| el | Greek |
+| en-AU | English (Australia) |
+| en-BZ | English (Belize) |
+| en | English |
+| en-CA | English (Canada) |
+| en-GB | English (United Kingdom) |
+| en-IE | English (Ireland) |
+| en-JM | English (Jamaica) |
+| en-NZ | English (New Zealand) |
+| en-PH | English (Philippines) |
+| en-TT | English (Trinidad & Tobago) |
+| en-US | English (United States) |
+| en-ZA | English (South Africa) |
+| en-ZW | English (Zimbabwe) |
+| eo | Esperanto |
+| et | Estonian |
+| eu | Basque |
+| fa | Persian |
+| fa | Farsi |
+| fa-IR | Persian/Iran |
+| fi | Finnish |
+| fj | Fijian |
+| fo | Faeroese |
+| fr-CH | French (Switzerland) |
+| fr-FR | French (France) |
+| fr-LU | French (Luxembourg) |
+| fr-MC | French (Monaco) |
+| fr | French (Standard) |
+| fr-BE | French (Belgium) |
+| fr-CA | French (Canada) |
+| fur | Friulian |
+| fy | Frisian |
+| ga | Irish |
+| gd-IE | Gaelic (Irish) |
+| gd | Gaelic (Scots) |
+| gl | Galacian |
+| gu | Gujurati |
+| he | Hebrew |
+| hi | Hindi |
+| hr | Croatian |
+| ht | Haitian |
+| hu | Hungarian |
+| hy | Armenian |
+| id | Indonesian |
+| is | Icelandic |
+| it-CH | Italian (Switzerland) |
+| it | Italian (Standard) |
+| iu | Inuktitut |
+| ja | Japanese |
+| ka | Georgian |
+| kk | Kazakh |
+| km | Khmer |
+| kn | Kannada |
+| ko | Korean |
+| ko-KP | Korean (North Korea) |
+| ko-KR | Korean (South Korea) |
+| ks | Kashmiri |
+| ky | Kirghiz |
+| la | Latin |
+| lb | Luxembourgish |
+| lt | Lithuanian |
+| lv | Latvian |
+| mi | Maori |
+| mk | FYRO Macedonian |
+| ml | Malayalam |
+| mo | Moldavian |
+| mr | Marathi |
+| ms | Malay |
+| mt | Maltese |
+| my | Burmese |
+| nb | Norwegian (Bokmal) |
+| ne | Nepali |
+| ng | Ndonga |
+| nl | Dutch (Standard) |
+| nl-BE | Dutch (Belgian) |
+| nn | Norwegian (Nynorsk) |
+| no | Norwegian |
+| nv | Navajo |
+| oc | Occitan |
+| om | Oromo |
+| or | Oriya |
+| sq | Albanian |
+| tlh | Klingon |
+| zh-TW | Chinese (Taiwan) |
+| zh | Chinese |
+| zh-CN | Chinese (PRC) |
+| zh-HK | Chinese (Hong Kong) |
+| zh-SG | Chinese (Singapore) |

--- a/test/fixtures/electron/docs/api/menu-item.md
+++ b/test/fixtures/electron/docs/api/menu-item.md
@@ -13,31 +13,31 @@ Create a new `MenuItem` with the following method:
 ### `new MenuItem(options)`
 
 * `options` Object
-  * `click` Function - Will be called with
+  * `click` Function - (optional) Will be called with
     `click(menuItem, browserWindow, event)` when the menu item is clicked.
     * `menuItem` MenuItem
     * `browserWindow` BrowserWindow
     * `event` Event
-  * `role` String - Define the action of the menu item, when specified the
+  * `role` String - (optional) Define the action of the menu item, when specified the
     `click` property will be ignored.
-  * `type` String - Can be `normal`, `separator`, `submenu`, `checkbox` or
+  * `type` String - (optional) Can be `normal`, `separator`, `submenu`, `checkbox` or
     `radio`.
-  * `label` String
-  * `sublabel` String
-  * `accelerator` [Accelerator](accelerator.md)
-  * `icon` [NativeImage](native-image.md)
-  * `enabled` Boolean - If false, the menu item will be greyed out and
+  * `label` String - (optional)
+  * `sublabel` String - (optional)
+  * `accelerator` [Accelerator](accelerator.md) - (optional)
+  * `icon` ([NativeImage](native-image.md) | String) - (optional)
+  * `enabled` Boolean - (optional) If false, the menu item will be greyed out and
     unclickable.
-  * `visible` Boolean - If false, the menu item will be entirely hidden.
-  * `checked` Boolean - Should only be specified for `checkbox` or `radio` type
+  * `visible` Boolean - (optional) If false, the menu item will be entirely hidden.
+  * `checked` Boolean - (optional) Should only be specified for `checkbox` or `radio` type
     menu items.
-  * `submenu` Menu - Should be specified for `submenu` type menu items. If
+  * `submenu` MenuItemConstructorOptions[] - (optional) Should be specified for `submenu` type menu items. If
     `submenu` is specified, the `type: 'submenu'` can be omitted. If the value
     is not a `Menu` then it will be automatically converted to one using
     `Menu.buildFromTemplate`.
-  * `id` String - Unique within a single menu. If defined then it can be used
+  * `id` String - (optional) Unique within a single menu. If defined then it can be used
     as a reference to this item by the position attribute.
-  * `position` String - This field allows fine-grained definition of the
+  * `position` String - (optional) This field allows fine-grained definition of the
     specific location within a given menu.
 
 It is best to specify `role` for any menu item that matches a standard role,

--- a/test/fixtures/electron/docs/api/menu-item.md
+++ b/test/fixtures/electron/docs/api/menu-item.md
@@ -1,0 +1,110 @@
+# MenuItem
+
+> Add items to native application menus and context menus.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+See [`Menu`](menu.md) for examples.
+
+## Class: MenuItem
+
+Create a new `MenuItem` with the following method:
+
+### `new MenuItem(options)`
+
+* `options` Object
+  * `click` Function - Will be called with
+    `click(menuItem, browserWindow, event)` when the menu item is clicked.
+    * `menuItem` MenuItem
+    * `browserWindow` BrowserWindow
+    * `event` Event
+  * `role` String - Define the action of the menu item, when specified the
+    `click` property will be ignored.
+  * `type` String - Can be `normal`, `separator`, `submenu`, `checkbox` or
+    `radio`.
+  * `label` String
+  * `sublabel` String
+  * `accelerator` [Accelerator](accelerator.md)
+  * `icon` [NativeImage](native-image.md)
+  * `enabled` Boolean - If false, the menu item will be greyed out and
+    unclickable.
+  * `visible` Boolean - If false, the menu item will be entirely hidden.
+  * `checked` Boolean - Should only be specified for `checkbox` or `radio` type
+    menu items.
+  * `submenu` Menu - Should be specified for `submenu` type menu items. If
+    `submenu` is specified, the `type: 'submenu'` can be omitted. If the value
+    is not a `Menu` then it will be automatically converted to one using
+    `Menu.buildFromTemplate`.
+  * `id` String - Unique within a single menu. If defined then it can be used
+    as a reference to this item by the position attribute.
+  * `position` String - This field allows fine-grained definition of the
+    specific location within a given menu.
+
+It is best to specify `role` for any menu item that matches a standard role,
+rather than trying to manually implement the behavior in a `click` function.
+The built-in `role` behavior will give the best native experience.
+
+The `label` and `accelerator` are optional when using a `role` and will default
+to appropriate values for each platform.
+
+The `role` property can have following values:
+
+* `undo`
+* `redo`
+* `cut`
+* `copy`
+* `paste`
+* `pasteandmatchstyle`
+* `selectall`
+* `delete`
+* `minimize` - Minimize current window
+* `close` - Close current window
+* `quit`- Quit the application
+* `togglefullscreen`- Toggle full screen mode on the current window
+* `resetzoom` - Reset the focused page's zoom level to the original size
+* `zoomin` - Zoom in the focused page by 10%
+* `zoomout` - Zoom out the focused page by 10%
+
+On macOS `role` can also have following additional values:
+
+* `about` - Map to the `orderFrontStandardAboutPanel` action
+* `hide` - Map to the `hide` action
+* `hideothers` - Map to the `hideOtherApplications` action
+* `unhide` - Map to the `unhideAllApplications` action
+* `startspeaking` - Map to the `startSpeaking` action
+* `stopspeaking` - Map to the `stopSpeaking` action
+* `front` - Map to the `arrangeInFront` action
+* `zoom` - Map to the `performZoom` action
+* `window` - The submenu is a "Window" menu
+* `help` - The submenu is a "Help" menu
+* `services` - The submenu is a "Services" menu
+
+When specifying `role` on macOS, `label` and `accelerator` are the only options
+that will affect the MenuItem. All other options will be ignored.
+
+### Instance Properties
+
+The following properties are available on instances of `MenuItem`:
+
+#### `menuItem.enabled`
+
+A Boolean indicating whether the item is enabled, this property can be
+dynamically changed.
+
+#### `menuItem.visible`
+
+A Boolean indicating whether the item is visible, this property can be
+dynamically changed.
+
+#### `menuItem.checked`
+
+A Boolean indicating whether the item is checked, this property can be
+dynamically changed.
+
+A `checkbox` menu item will toggle the `checked` property on and off when
+selected.
+
+A `radio` menu item will turn on its `checked` property when clicked, and
+will turn off that property for all adjacent items in the same menu.
+
+You can add a `click` function for additional behavior.

--- a/test/fixtures/electron/docs/api/menu.md
+++ b/test/fixtures/electron/docs/api/menu.md
@@ -238,7 +238,7 @@ will be set as each window's top menu.
 
 #### `Menu.getApplicationMenu()`
 
-Returns the application menu (an instance of `Menu`), if set, or `null`, if not set.
+Returns `Menu` - The application menu, if set, or `null`, if not set.
 
 #### `Menu.sendActionToFirstResponder(action)` _macOS_
 
@@ -253,7 +253,9 @@ for more information on macOS' native actions.
 
 #### `Menu.buildFromTemplate(template)`
 
-* `template` MenuItem[]
+* `template` MenuItemConstructorOptions[]
+
+Returns `Menu`
 
 Generally, the `template` is just an array of `options` for constructing a
 [MenuItem](menu-item.md). The usage can be referenced above.

--- a/test/fixtures/electron/docs/api/menu.md
+++ b/test/fixtures/electron/docs/api/menu.md
@@ -1,0 +1,410 @@
+# Menu
+
+> Create native application menus and context menus.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+Each `Menu` consists of multiple [`MenuItem`](menu-item.md)s and each `MenuItem`
+can have a submenu.
+
+## Examples
+
+The `Menu` class is only available in the main process, but you can also use it
+in the render process via the [`remote`](remote.md) module.
+
+### Main process
+
+An example of creating the application menu in the main process with the
+simple template API:
+
+```javascript
+const {app, Menu} = require('electron')
+
+const template = [
+  {
+    label: 'Edit',
+    submenu: [
+      {
+        role: 'undo'
+      },
+      {
+        role: 'redo'
+      },
+      {
+        type: 'separator'
+      },
+      {
+        role: 'cut'
+      },
+      {
+        role: 'copy'
+      },
+      {
+        role: 'paste'
+      },
+      {
+        role: 'pasteandmatchstyle'
+      },
+      {
+        role: 'delete'
+      },
+      {
+        role: 'selectall'
+      }
+    ]
+  },
+  {
+    label: 'View',
+    submenu: [
+      {
+        label: 'Reload',
+        accelerator: 'CmdOrCtrl+R',
+        click (item, focusedWindow) {
+          if (focusedWindow) focusedWindow.reload()
+        }
+      },
+      {
+        label: 'Toggle Developer Tools',
+        accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
+        click (item, focusedWindow) {
+          if (focusedWindow) focusedWindow.webContents.toggleDevTools()
+        }
+      },
+      {
+        type: 'separator'
+      },
+      {
+        role: 'resetzoom'
+      },
+      {
+        role: 'zoomin'
+      },
+      {
+        role: 'zoomout'
+      },
+      {
+        type: 'separator'
+      },
+      {
+        role: 'togglefullscreen'
+      }
+    ]
+  },
+  {
+    role: 'window',
+    submenu: [
+      {
+        role: 'minimize'
+      },
+      {
+        role: 'close'
+      }
+    ]
+  },
+  {
+    role: 'help',
+    submenu: [
+      {
+        label: 'Learn More',
+        click () { require('electron').shell.openExternal('http://electron.atom.io') }
+      }
+    ]
+  }
+]
+
+if (process.platform === 'darwin') {
+  template.unshift({
+    label: app.getName(),
+    submenu: [
+      {
+        role: 'about'
+      },
+      {
+        type: 'separator'
+      },
+      {
+        role: 'services',
+        submenu: []
+      },
+      {
+        type: 'separator'
+      },
+      {
+        role: 'hide'
+      },
+      {
+        role: 'hideothers'
+      },
+      {
+        role: 'unhide'
+      },
+      {
+        type: 'separator'
+      },
+      {
+        role: 'quit'
+      }
+    ]
+  })
+  // Edit menu.
+  template[1].submenu.push(
+    {
+      type: 'separator'
+    },
+    {
+      label: 'Speech',
+      submenu: [
+        {
+          role: 'startspeaking'
+        },
+        {
+          role: 'stopspeaking'
+        }
+      ]
+    }
+  )
+  // Window menu.
+  template[3].submenu = [
+    {
+      label: 'Close',
+      accelerator: 'CmdOrCtrl+W',
+      role: 'close'
+    },
+    {
+      label: 'Minimize',
+      accelerator: 'CmdOrCtrl+M',
+      role: 'minimize'
+    },
+    {
+      label: 'Zoom',
+      role: 'zoom'
+    },
+    {
+      type: 'separator'
+    },
+    {
+      label: 'Bring All to Front',
+      role: 'front'
+    }
+  ]
+}
+
+const menu = Menu.buildFromTemplate(template)
+Menu.setApplicationMenu(menu)
+```
+
+### Render process
+
+Below is an example of creating a menu dynamically in a web page
+(render process) by using the [`remote`](remote.md) module, and showing it when
+the user right clicks the page:
+
+```html
+<!-- index.html -->
+<script>
+const {remote} = require('electron')
+const {Menu, MenuItem} = remote
+
+const menu = new Menu()
+menu.append(new MenuItem({label: 'MenuItem1', click() { console.log('item 1 clicked') }}))
+menu.append(new MenuItem({type: 'separator'}))
+menu.append(new MenuItem({label: 'MenuItem2', type: 'checkbox', checked: true}))
+
+window.addEventListener('contextmenu', (e) => {
+  e.preventDefault()
+  menu.popup(remote.getCurrentWindow())
+}, false)
+</script>
+```
+
+## Class: Menu
+
+### `new Menu()`
+
+Creates a new menu.
+
+### Static Methods
+
+The `menu` class has the following static methods:
+
+#### `Menu.setApplicationMenu(menu)`
+
+* `menu` Menu
+
+Sets `menu` as the application menu on macOS. On Windows and Linux, the `menu`
+will be set as each window's top menu.
+
+**Note:** This API has to be called after the `ready` event of `app` module.
+
+#### `Menu.getApplicationMenu()`
+
+Returns the application menu (an instance of `Menu`), if set, or `null`, if not set.
+
+#### `Menu.sendActionToFirstResponder(action)` _macOS_
+
+* `action` String
+
+Sends the `action` to the first responder of application. This is used for
+emulating default Cocoa menu behaviors, usually you would just use the
+`role` property of `MenuItem`.
+
+See the [macOS Cocoa Event Handling Guide](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/EventOverview/EventArchitecture/EventArchitecture.html#//apple_ref/doc/uid/10000060i-CH3-SW7)
+for more information on macOS' native actions.
+
+#### `Menu.buildFromTemplate(template)`
+
+* `template` MenuItem[]
+
+Generally, the `template` is just an array of `options` for constructing a
+[MenuItem](menu-item.md). The usage can be referenced above.
+
+You can also attach other fields to the element of the `template` and they
+will become properties of the constructed menu items.
+
+### Instance Methods
+
+The `menu` object has the following instance methods:
+
+#### `menu.popup([browserWindow, x, y, positioningItem])`
+
+* `browserWindow` BrowserWindow (optional) - Default is `BrowserWindow.getFocusedWindow()`.
+* `x` Number (optional) - Default is the current mouse cursor position.
+* `y` Number (**required** if `x` is used) - Default is the current mouse cursor position.
+* `positioningItem` Number (optional) _macOS_ - The index of the menu item to
+  be positioned under the mouse cursor at the specified coordinates. Default is
+  -1.
+
+Pops up this menu as a context menu in the `browserWindow`.
+
+#### `menu.append(menuItem)`
+
+* `menuItem` MenuItem
+
+Appends the `menuItem` to the menu.
+
+#### `menu.insert(pos, menuItem)`
+
+* `pos` Integer
+* `menuItem` MenuItem
+
+Inserts the `menuItem` to the `pos` position of the menu.
+
+### Instance Properties
+
+`menu` objects also have the following properties:
+
+#### `menu.items`
+
+A MenuItem[] array containing the menu's items.
+
+## Notes on macOS Application Menu
+
+macOS has a completely different style of application menu from Windows and
+Linux. Here are some notes on making your app's menu more native-like.
+
+### Standard Menus
+
+On macOS there are many system-defined standard menus, like the `Services` and
+`Windows` menus. To make your menu a standard menu, you should set your menu's
+`role` to one of following and Electron will recognize them and make them
+become standard menus:
+
+* `window`
+* `help`
+* `services`
+
+### Standard Menu Item Actions
+
+macOS has provided standard actions for some menu items, like `About xxx`,
+`Hide xxx`, and `Hide Others`. To set the action of a menu item to a standard
+action, you should set the `role` attribute of the menu item.
+
+### Main Menu's Name
+
+On macOS the label of the application menu's first item is always your app's
+name, no matter what label you set. To change it, modify your app bundle's
+`Info.plist` file. See
+[About Information Property List Files][AboutInformationPropertyListFiles]
+for more information.
+
+## Setting Menu for Specific Browser Window (*Linux* *Windows*)
+
+The [`setMenu` method][setMenu] of browser windows can set the menu of certain
+browser windows.
+
+## Menu Item Position
+
+You can make use of `position` and `id` to control how the item will be placed
+when building a menu with `Menu.buildFromTemplate`.
+
+The `position` attribute of `MenuItem` has the form `[placement]=[id]`, where
+`placement` is one of `before`, `after`, or `endof` and `id` is the unique ID of
+an existing item in the menu:
+
+* `before` - Inserts this item before the id referenced item. If the
+  referenced item doesn't exist the item will be inserted at the end of
+  the menu.
+* `after` - Inserts this item after id referenced item. If the referenced
+  item doesn't exist the item will be inserted at the end of the menu.
+* `endof` - Inserts this item at the end of the logical group containing
+  the id referenced item (groups are created by separator items). If
+  the referenced item doesn't exist, a new separator group is created with
+  the given id and this item is inserted after that separator.
+
+When an item is positioned, all un-positioned items are inserted after
+it until a new item is positioned. So if you want to position a group of
+menu items in the same location you only need to specify a position for
+the first item.
+
+### Examples
+
+Template:
+
+```javascript
+[
+  {label: '4', id: '4'},
+  {label: '5', id: '5'},
+  {label: '1', id: '1', position: 'before=4'},
+  {label: '2', id: '2'},
+  {label: '3', id: '3'}
+]
+```
+
+Menu:
+
+```
+- 1
+- 2
+- 3
+- 4
+- 5
+```
+
+Template:
+
+```javascript
+[
+  {label: 'a', position: 'endof=letters'},
+  {label: '1', position: 'endof=numbers'},
+  {label: 'b', position: 'endof=letters'},
+  {label: '2', position: 'endof=numbers'},
+  {label: 'c', position: 'endof=letters'},
+  {label: '3', position: 'endof=numbers'}
+]
+```
+
+Menu:
+
+```
+- ---
+- a
+- b
+- c
+- ---
+- 1
+- 2
+- 3
+```
+
+[AboutInformationPropertyListFiles]: https://developer.apple.com/library/ios/documentation/general/Reference/InfoPlistKeyReference/Articles/AboutInformationPropertyListFiles.html
+[setMenu]: https://github.com/electron/electron/blob/master/docs/api/browser-window.md#winsetmenumenu-linux-windows

--- a/test/fixtures/electron/docs/api/native-image.md
+++ b/test/fixtures/electron/docs/api/native-image.md
@@ -1,0 +1,254 @@
+# nativeImage
+
+> Create tray, dock, and application icons using PNG or JPG files.
+
+Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+
+In Electron, for the APIs that take images, you can pass either file paths or
+`NativeImage` instances. An empty image will be used when `null` is passed.
+
+For example, when creating a tray or setting a window's icon, you can pass an
+image file path as a `String`:
+
+```javascript
+const {BrowserWindow, Tray} = require('electron')
+
+const appIcon = new Tray('/Users/somebody/images/icon.png')
+let win = new BrowserWindow({icon: '/Users/somebody/images/window.png'})
+console.log(appIcon, win)
+```
+
+Or read the image from the clipboard which returns a `nativeImage`:
+
+```javascript
+const {clipboard, Tray} = require('electron')
+const image = clipboard.readImage()
+const appIcon = new Tray(image)
+console.log(appIcon)
+```
+
+## Supported Formats
+
+Currently `PNG` and `JPEG` image formats are supported. `PNG` is recommended
+because of its support for transparency and lossless compression.
+
+On Windows, you can also load `ICO` icons from file paths. For best visual
+quality it is recommended to include at least the following sizes in the:
+
+* Small icon
+ * 16x16 (100% DPI scale)
+ * 20x20 (125% DPI scale)
+ * 24x24 (150% DPI scale)
+ * 32x32 (200% DPI scale)
+* Large icon
+ * 32x32 (100% DPI scale)
+ * 40x40 (125% DPI scale)
+ * 48x48 (150% DPI scale)
+ * 64x64 (200% DPI scale)
+* 256x256
+
+Check the *Size requirements* section in [this article][icons].
+
+[icons]:https://msdn.microsoft.com/en-us/library/windows/desktop/dn742485(v=vs.85).aspx
+
+## High Resolution Image
+
+On platforms that have high-DPI support such as Apple Retina displays, you can
+append `@2x` after image's base filename to mark it as a high resolution image.
+
+For example if `icon.png` is a normal image that has standard resolution, then
+`icon@2x.png` will be treated as a high resolution image that has double DPI
+density.
+
+If you want to support displays with different DPI densities at the same time,
+you can put images with different sizes in the same folder and use the filename
+without DPI suffixes. For example:
+
+```text
+images/
+├── icon.png
+├── icon@2x.png
+└── icon@3x.png
+```
+
+
+```javascript
+const {Tray} = require('electron')
+let appIcon = new Tray('/Users/somebody/images/icon.png')
+console.log(appIcon)
+```
+
+Following suffixes for DPI are also supported:
+
+* `@1x`
+* `@1.25x`
+* `@1.33x`
+* `@1.4x`
+* `@1.5x`
+* `@1.8x`
+* `@2x`
+* `@2.5x`
+* `@3x`
+* `@4x`
+* `@5x`
+
+## Template Image
+
+Template images consist of black and clear colors (and an alpha channel).
+Template images are not intended to be used as standalone images and are usually
+mixed with other content to create the desired final appearance.
+
+The most common case is to use template images for a menu bar icon so it can
+adapt to both light and dark menu bars.
+
+**Note:** Template image is only supported on macOS.
+
+To mark an image as a template image, its filename should end with the word
+`Template`. For example:
+
+* `xxxTemplate.png`
+* `xxxTemplate@2x.png`
+
+## Methods
+
+The `nativeImage` module has the following methods, all of which return
+an instance of the `NativeImage` class:
+
+### `nativeImage.createEmpty()`
+
+Returns `NativeImage`
+
+Creates an empty `NativeImage` instance.
+
+### `nativeImage.createFromPath(path)`
+
+* `path` String
+
+Returns `NativeImage`
+
+Creates a new `NativeImage` instance from a file located at `path`. This method
+returns an empty image if the `path` does not exist, cannot be read, or is not
+a valid image.
+
+```javascript
+const nativeImage = require('electron').nativeImage
+
+let image = nativeImage.createFromPath('/Users/somebody/images/icon.png')
+console.log(image)
+```
+
+### `nativeImage.createFromBuffer(buffer[, scaleFactor])`
+
+* `buffer` [Buffer][buffer]
+* `scaleFactor` Double (optional)
+
+Returns `NativeImage`
+
+Creates a new `NativeImage` instance from `buffer`. The default `scaleFactor` is
+1.0.
+
+### `nativeImage.createFromDataURL(dataURL)`
+
+* `dataURL` String
+
+Creates a new `NativeImage` instance from `dataURL`.
+
+## Class: NativeImage
+
+> Natively wrap images such as tray, dock, and application icons.
+
+Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+
+### Instance Methods
+
+The following methods are available on instances of the `NativeImage` class:
+
+#### `image.toPNG()`
+
+Returns `Buffer` - A [Buffer][buffer] that contains the image's `PNG` encoded data.
+
+#### `image.toJPEG(quality)`
+
+* `quality` Integer (**required**) - Between 0 - 100.
+
+Returns `Buffer` - A [Buffer][buffer] that contains the image's `JPEG` encoded data.
+
+#### `image.toBitmap()`
+
+Returns `Buffer` - A [Buffer][buffer] that contains a copy of the image's raw bitmap pixel
+data.
+
+#### `image.toDataURL()`
+
+Returns `String` - The data URL of the image.
+
+#### `image.getBitmap()`
+
+Returns `Buffer` - A [Buffer][buffer] that contains the image's raw bitmap pixel data.
+
+The difference between `getBitmap()` and `toBitmap()` is, `getBitmap()` does not
+copy the bitmap data, so you have to use the returned Buffer immediately in
+current event loop tick, otherwise the data might be changed or destroyed.
+
+#### `image.getNativeHandle()` _macOS_
+
+Returns `Buffer` - A [Buffer][buffer] that stores C pointer to underlying native handle of
+the image. On macOS, a pointer to `NSImage` instance would be returned.
+
+Notice that the returned pointer is a weak pointer to the underlying native
+image instead of a copy, so you _must_ ensure that the associated
+`nativeImage` instance is kept around.
+
+#### `image.isEmpty()`
+
+Returns `Boolean` -  Whether the image is empty.
+
+#### `image.getSize()`
+
+Returns `Object`:
+
+* `width` Integer
+* `height` Integer
+
+#### `image.setTemplateImage(option)`
+
+* `option` Boolean
+
+Marks the image as a template image.
+
+#### `image.isTemplateImage()`
+
+Returns `Boolean` - Whether the image is a template image.
+
+#### `image.crop(rect)`
+
+* `rect` Object - The area of the image to crop
+  * `x` Integer
+  * `y` Integer
+  * `width` Integer
+  * `height` Integer
+
+Returns `NativeImage` - The cropped image.
+
+#### `image.resize(options)`
+
+* `options` Object
+  * `width` Integer (optional)
+  * `height` Integer (optional)
+  * `quality` String (optional) - The desired quality of the resize image.
+    Possible values are `good`, `better` or `best`. The default is `best`.
+    These values express a desired quality/speed tradeoff. They are translated
+    into an algorithm-specific method that depends on the capabilities
+    (CPU, GPU) of the underlying platform. It is possible for all three methods
+    to be mapped to the same algorithm on a given platform.
+
+Returns `NativeImage` - The resized image.
+
+If only the `height` or the `width` are specified then the current aspect ratio
+will be preserved in the resized image.
+
+#### `image.getAspectRatio()`
+
+Returns `Float` - The image's aspect ratio.
+
+[buffer]: https://nodejs.org/api/buffer.html#buffer_class_buffer

--- a/test/fixtures/electron/docs/api/net.md
+++ b/test/fixtures/electron/docs/api/net.md
@@ -1,0 +1,332 @@
+# net
+
+> Issue HTTP/HTTPS requests using Chromium's native networking library
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+The `net` module is a client-side API for issuing HTTP(S) requests. It is
+similar to the [HTTP](https://nodejs.org/api/http.html) and
+[HTTPS](https://nodejs.org/api/https.html) modules of Node.js but uses
+Chromium's native networking library instead of the Node.js implementation,
+offering better support for web proxies.
+
+The following is a non-exhaustive list of why you may consider using the `net`
+module instead of the native Node.js modules:
+
+* Automatic management of system proxy configuration, support of the wpad
+  protocol and proxy pac configuration files.
+* Automatic tunneling of HTTPS requests.
+* Support for authenticating proxies using basic, digest, NTLM, Kerberos or
+  negotiate authentication schemes.
+* Support for traffic monitoring proxies: Fiddler-like proxies used for access
+  control and monitoring.
+
+The `net` module API has been specifically designed to mimic, as closely as
+possible, the familiar Node.js API. The API components including classes,
+methods, properties and event names are similar to those commonly used in
+Node.js.
+
+For instance, the following example quickly shows how the `net` API might be
+used:
+
+```javascript
+const {app} = require('electron')
+app.on('ready', () => {
+  const {net} = require('electron')
+  const request = net.request('https://github.com')
+  request.on('response', (response) => {
+    console.log(`STATUS: ${response.statusCode}`)
+    console.log(`HEADERS: ${JSON.stringify(response.headers)}`)
+    response.on('data', (chunk) => {
+      console.log(`BODY: ${chunk}`)
+    })
+    response.on('end', () => {
+      console.log('No more data in response.')
+    })
+  })
+  request.end()
+})
+```
+
+By the way, it is almost identical to how you would normally use the
+[HTTP](https://nodejs.org/api/http.html)/[HTTPS](https://nodejs.org/api/https.html)
+modules of Node.js
+
+The `net` API can be used only after the application emits the `ready` event.
+Trying to use the module before the `ready` event will throw an error.
+
+## Methods
+
+The `net` module has the following methods:
+
+### `net.request(options)`
+
+* `options` (Object | String) - The `ClientRequest` constructor options.
+
+Returns `ClientRequest`
+
+Creates a `ClientRequest` instance using the provided `options` which are
+directly forwarded to the `ClientRequest` constructor. The `net.request` method
+would be used to issue both secure and insecure HTTP requests according to the
+specified protocol scheme in the `options` object.
+
+## Class: ClientRequest
+
+> Make HTTP/HTTPS requests.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+`ClientRequest` implements the [Writable Stream](https://nodejs.org/api/stream.html#stream_writable_streams)
+interface and is therefore an [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter).
+
+### `new ClientRequest(options)`
+
+* `options` (Object | String) - If `options` is a String, it is interpreted as
+  the request URL. If it is an object, it is expected to fully specify an HTTP
+  request via the following properties:
+  * `method` String (optional) - The HTTP request method. Defaults to the GET
+    method.
+  * `url` String (optional) - The request URL. Must be provided in the absolute
+    form with the protocol scheme specified as http or https.
+  * `session` Object (optional) - The [`Session`](session.md) instance with
+    which the request is associated.
+  * `partition` String (optional) - The name of the [`partition`](session.md)
+    with which the request is associated. Defaults to the empty string. The
+    `session` option prevails on `partition`. Thus if a `session` is explicitly
+    specified, `partition` is ignored.
+  * `protocol` String (optional) - The protocol scheme in the form 'scheme:'.
+    Currently supported values are 'http:' or 'https:'. Defaults to 'http:'.
+  * `host` String (optional) - The server host provided as a concatenation of
+    the hostname and the port number 'hostname:port'
+  * `hostname` String (optional) - The server host name.
+  * `port` Integer (optional) - The server's listening port number.
+  * `path` String (optional) - The path part of the request URL.
+
+`options` properties such as `protocol`, `host`, `hostname`, `port` and `path`
+strictly follow the Node.js model as described in the
+[URL](https://nodejs.org/api/url.html) module.
+
+For instance, we could have created the same request to 'github.com' as follows:
+
+```javascript
+const request = net.request({
+  method: 'GET',
+  protocol: 'https:',
+  hostname: 'github.com',
+  port: 443,
+  path: '/'
+})
+```
+
+### Instance Events
+
+#### Event: 'response'
+
+Returns:
+
+* `response` IncomingMessage - An object representing the HTTP response message.
+
+#### Event: 'login'
+
+Returns:
+
+* `authInfo` Object
+  * `isProxy` Boolean
+  * `scheme` String
+  * `host` String
+  * `port` Integer
+  * `realm` String
+* `callback` Function
+
+Emitted when an authenticating proxy is asking for user credentials.
+
+The `callback` function is expected to be called back with user credentials:
+
+* `username` String
+* `password` String
+
+```javascript
+request.on('login', (authInfo, callback) => {
+  callback('username', 'password')
+})
+```
+
+Providing empty credentials will cancel the request and report an authentication
+error on the response object:
+
+```javascript
+request.on('response', (response) => {
+  console.log(`STATUS: ${response.statusCode}`)
+  response.on('error', (error) => {
+    console.log(`ERROR: ${JSON.stringify(error)}`)
+  })
+})
+request.on('login', (authInfo, callback) => {
+  callback()
+})
+```
+
+#### Event: 'finish'
+
+Emitted just after the last chunk of the `request`'s data has been written into
+the `request` object.
+
+#### Event: 'abort'
+
+Emitted when the `request` is aborted. The `abort` event will not be fired if
+the `request` is already closed.
+
+#### Event: 'error'
+
+Returns:
+
+* `error` Error - an error object providing some information about the failure.
+
+Emitted when the `net` module fails to issue a network request. Typically when
+the `request` object emits an `error` event, a `close` event will subsequently
+follow and no response object will be provided.
+
+#### Event: 'close'
+
+Emitted as the last event in the HTTP request-response transaction. The `close`
+event indicates that no more events will be emitted on either the `request` or
+`response` objects.
+
+### Instance Properties
+
+#### `request.chunkedEncoding`
+
+A Boolean specifying whether the request will use HTTP chunked transfer encoding
+or not. Defaults to false. The property is readable and writable, however it can
+be set only before the first write operation as the HTTP headers are not yet put
+on the wire. Trying to set the `chunkedEncoding` property after the first write
+will throw an error.
+
+Using chunked encoding is strongly recommended if you need to send a large
+request body as data will be streamed in small chunks instead of being
+internally buffered inside Electron process memory.
+
+### Instance Methods
+
+#### `request.setHeader(name, value)`
+
+* `name` String - An extra HTTP header name.
+* `value` String - An extra HTTP header value.
+
+Adds an extra HTTP header. The header name will issued as it is without
+lowercasing. It can be called only before first write. Calling this method after
+the first write will throw an error.
+
+#### `request.getHeader(name)`
+
+* `name` String - Specify an extra header name.
+
+Returns String - The value of a previously set extra header name.
+
+#### `request.removeHeader(name)`
+
+* `name` String - Specify an extra header name.
+
+Removes a previously set extra header name. This method can be called only
+before first write. Trying to call it after the first write will throw an error.
+
+#### `request.write(chunk[, encoding][, callback])`
+
+* `chunk` (String | Buffer) - A chunk of the request body's data. If it is a
+  string, it is converted into a Buffer using the specified encoding.
+* `encoding` String (optional) - Used to convert string chunks into Buffer
+  objects. Defaults to 'utf-8'.
+* `callback` Function (optional) - Called after the write operation ends.
+
+`callback` is essentially a dummy function introduced in the purpose of keeping
+similarity with the Node.js API. It is called asynchronously in the next tick
+after `chunk` content have been delivered to the Chromium networking layer.
+Contrary to the Node.js implementation, it is not guaranteed that `chunk`
+content have been flushed on the wire before `callback` is called.
+
+Adds a chunk of data to the request body. The first write operation may cause
+the request headers to be issued on the wire. After the first write operation,
+it is not allowed to add or remove a custom header.
+
+#### `request.end([chunk][, encoding][, callback])`
+
+* `chunk` (String | Buffer) (optional)
+* `encoding` String (optional)
+* `callback` Function (optional)
+
+Sends the last chunk of the request data. Subsequent write or end operations
+will not be allowed. The `finish` event is emitted just after the end operation.
+
+#### `request.abort()`
+
+Cancels an ongoing HTTP transaction. If the request has already emitted the
+`close` event, the abort operation will have no effect. Otherwise an ongoing
+event will emit `abort` and `close` events. Additionally, if there is an ongoing
+response object,it will emit the `aborted` event.
+
+## Class: IncomingMessage
+
+> Handle responses to HTTP/HTTPS requests.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+`IncomingMessage` implements the [Readable Stream](https://nodejs.org/api/stream.html#stream_readable_streams)
+interface and is therefore an [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter).
+
+### Instance Events
+
+#### Event: 'data'
+
+Returns:
+
+* `chunk` Buffer - A chunk of response body's data.
+
+The `data` event is the usual method of transferring response data into
+applicative code.
+
+#### Event: 'end'
+
+Indicates that response body has ended.
+
+#### Event: 'aborted'
+
+Emitted when a request has been canceled during an ongoing HTTP transaction.
+
+#### Event: 'error'
+
+Returns:
+
+`error` Error - Typically holds an error string identifying failure root cause.
+
+Emitted when an error was encountered while streaming response data events. For
+instance, if the server closes the underlying while the response is still
+streaming, an `error` event will be emitted on the response object and a `close`
+event will subsequently follow on the request object.
+
+### Instance Properties
+
+An `IncomingMessage` instance has the following readable properties:
+
+#### `response.statusCode`
+
+An Integer indicating the HTTP response status code.
+
+#### `response.statusMessage`
+
+A String representing the HTTP status message.
+
+#### `response.headers`
+
+An Object representing the response HTTP headers. The `headers` object is
+formatted as follows:
+
+* All header names are lowercased.
+* Each header name produces an array-valued property on the headers object.
+* Each header value is pushed into the array associated with its header name.
+
+#### `response.httpVersion`
+
+A String indicating the HTTP protocol version number. Typical values are '1.0'
+or '1.1'. Additionally `httpVersionMajor` and `httpVersionMinor` are two
+Integer-valued readable properties that return respectively the HTTP major and
+minor version numbers.

--- a/test/fixtures/electron/docs/api/power-monitor.md
+++ b/test/fixtures/electron/docs/api/power-monitor.md
@@ -1,0 +1,41 @@
+# powerMonitor
+
+> Monitor power state changes.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+You cannot require or use this module until the `ready` event of the `app`
+module is emitted.
+
+For example:
+
+```javascript
+const electron = require('electron')
+const {app} = electron
+
+app.on('ready', () => {
+  electron.powerMonitor.on('suspend', () => {
+    console.log('The system is going to sleep')
+  })
+})
+```
+
+## Events
+
+The `powerMonitor` module emits the following events:
+
+### Event: 'suspend'
+
+Emitted when the system is suspending.
+
+### Event: 'resume'
+
+Emitted when system is resuming.
+
+### Event: 'on-ac' _Windows_
+
+Emitted when the system changes to AC power.
+
+### Event: 'on-battery' _Windows_
+
+Emitted when system changes to battery power.

--- a/test/fixtures/electron/docs/api/power-save-blocker.md
+++ b/test/fixtures/electron/docs/api/power-save-blocker.md
@@ -1,0 +1,56 @@
+# powerSaveBlocker
+
+> Block the system from entering low-power (sleep) mode.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+For example:
+
+```javascript
+const {powerSaveBlocker} = require('electron')
+
+const id = powerSaveBlocker.start('prevent-display-sleep')
+console.log(powerSaveBlocker.isStarted(id))
+
+powerSaveBlocker.stop(id)
+```
+
+## Methods
+
+The `powerSaveBlocker` module has the following methods:
+
+### `powerSaveBlocker.start(type)`
+
+* `type` String - Power save blocker type.
+  * `prevent-app-suspension` - Prevent the application from being suspended.
+    Keeps system active but allows screen to be turned off.  Example use cases:
+    downloading a file or playing audio.
+  * `prevent-display-sleep` - Prevent the display from going to sleep. Keeps
+    system and screen active.  Example use case: playing video.
+
+Returns `Integer` - The blocker ID that is assigned to this power blocker
+
+Starts preventing the system from entering lower-power mode. Returns an integer
+identifying the power save blocker.
+
+**Note:** `prevent-display-sleep` has higher precedence over
+`prevent-app-suspension`. Only the highest precedence type takes effect. In
+other words, `prevent-display-sleep` always takes precedence over
+`prevent-app-suspension`.
+
+For example, an API calling A requests for `prevent-app-suspension`, and
+another calling B requests for `prevent-display-sleep`. `prevent-display-sleep`
+will be used until B stops its request. After that, `prevent-app-suspension`
+is used.
+
+### `powerSaveBlocker.stop(id)`
+
+* `id` Integer - The power save blocker id returned by `powerSaveBlocker.start`.
+
+Stops the specified power save blocker.
+
+### `powerSaveBlocker.isStarted(id)`
+
+* `id` Integer - The power save blocker id returned by `powerSaveBlocker.start`.
+
+Returns `Boolean` - Whether the corresponding `powerSaveBlocker` has started.

--- a/test/fixtures/electron/docs/api/process.md
+++ b/test/fixtures/electron/docs/api/process.md
@@ -1,0 +1,116 @@
+# process
+
+> Extensions to process object.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+The `process` object is extended in Electron with following APIs:
+
+## Events
+
+### Event: 'loaded'
+
+Emitted when Electron has loaded its internal initialization script and is
+beginning to load the web page or the main script.
+
+It can be used by the preload script to add removed Node global symbols back to
+the global scope when node integration is turned off:
+
+```javascript
+// preload.js
+const _setImmediate = setImmediate
+const _clearImmediate = clearImmediate
+process.once('loaded', () => {
+  global.setImmediate = _setImmediate
+  global.clearImmediate = _clearImmediate
+})
+```
+
+## Properties
+
+### `process.noAsar`
+
+Setting this to `true` can disable the support for `asar` archives in Node's
+built-in modules.
+
+### `process.type`
+
+Current process's type, can be `"browser"` (i.e. main process) or `"renderer"`.
+
+### `process.versions.electron`
+
+Electron's version string.
+
+### `process.versions.chrome`
+
+Chrome's version string.
+
+### `process.resourcesPath`
+
+Path to the resources directory.
+
+### `process.mas`
+
+For Mac App Store build, this property is `true`, for other builds it is
+`undefined`.
+
+### `process.windowsStore`
+
+If the app is running as a Windows Store app (appx), this property is `true`,
+for otherwise it is `undefined`.
+
+### `process.defaultApp`
+
+When app is started by being passed as parameter to the default app, this
+property is `true` in the main process, otherwise it is `undefined`.
+
+## Methods
+
+The `process` object has the following method:
+
+### `process.crash()`
+
+Causes the main thread of the current process crash.
+
+### `process.hang()`
+
+Causes the main thread of the current process hang.
+
+### `process.setFdLimit(maxDescriptors)` _macOS_ _Linux_
+
+* `maxDescriptors` Integer
+
+Sets the file descriptor soft limit to `maxDescriptors` or the OS hard
+limit, whichever is lower for the current process.
+
+### `process.getProcessMemoryInfo()`
+
+Returns `Object`:
+
+* `workingSetSize` Integer - The amount of memory currently pinned to actual physical
+  RAM.
+* `peakWorkingSetSize` Integer - The maximum amount of memory that has ever been pinned
+  to actual physical RAM.
+* `privateBytes` Integer - The amount of memory not shared by other processes, such as
+  JS heap or HTML content.
+* `sharedBytes` Integer - The amount of memory shared between processes, typically
+  memory consumed by the Electron code itself
+
+Returns an object giving memory usage statistics about the current process. Note
+that all statistics are reported in Kilobytes.
+
+### `process.getSystemMemoryInfo()`
+
+Returns `Object`:
+
+* `total` Integer - The total amount of physical memory in Kilobytes available to the
+  system.
+* `free` Integer - The total amount of memory not being used by applications or disk
+  cache.
+* `swapTotal` Integer - The total amount of swap memory in Kilobytes available to the
+  system.  _Windows_ _Linux_
+* `swapFree` Integer - The free amount of swap memory in Kilobytes available to the
+  system.  _Windows_ _Linux_
+
+Returns an object giving memory usage statistics about the entire system. Note
+that all statistics are reported in Kilobytes.

--- a/test/fixtures/electron/docs/api/protocol.md
+++ b/test/fixtures/electron/docs/api/protocol.md
@@ -1,0 +1,294 @@
+# protocol
+
+> Register a custom protocol and intercept existing protocol requests.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+An example of implementing a protocol that has the same effect as the
+`file://` protocol:
+
+```javascript
+const {app, protocol} = require('electron')
+const path = require('path')
+
+app.on('ready', () => {
+  protocol.registerFileProtocol('atom', (request, callback) => {
+    const url = request.url.substr(7)
+    callback({path: path.normalize(`${__dirname}/${url}`)})
+  }, (error) => {
+    if (error) console.error('Failed to register protocol')
+  })
+})
+```
+
+**Note:** All methods unless specified can only be used after the `ready` event
+of the `app` module gets emitted.
+
+## Methods
+
+The `protocol` module has the following methods:
+
+### `protocol.registerStandardSchemes(schemes)`
+
+* `schemes` String[] - Custom schemes to be registered as standard schemes.
+
+A standard scheme adheres to what RFC 3986 calls [generic URI
+syntax](https://tools.ietf.org/html/rfc3986#section-3). For example `http` and
+`https` are standard schemes, while `file` is not.
+
+Registering a scheme as standard, will allow relative and absolute resources to
+be resolved correctly when served. Otherwise the scheme will behave like the
+`file` protocol, but without the ability to resolve relative URLs.
+
+For example when you load following page with custom protocol without
+registering it as standard scheme, the image will not be loaded because
+non-standard schemes can not recognize relative URLs:
+
+```html
+<body>
+  <img src='test.png'>
+</body>
+```
+
+Registering a scheme as standard will allow access to files through the
+[FileSystem API][file-system-api]. Otherwise the renderer will throw a security
+error for the scheme.
+
+By default web storage apis (localStorage, sessionStorage, webSQL, indexedDB, cookies)
+are disabled for non standard schemes. So in general if you want to register a
+custom protocol to replace the `http` protocol, you have to register it as a standard scheme:
+
+```javascript
+const {app, protocol} = require('electron')
+
+protocol.registerStandardSchemes(['atom'])
+app.on('ready', () => {
+  protocol.registerHttpProtocol('atom', '...')
+})
+```
+
+**Note:** This method can only be used before the `ready` event of the `app`
+module gets emitted.
+
+### `protocol.registerServiceWorkerSchemes(schemes)`
+
+* `schemes` String[] - Custom schemes to be registered to handle service workers.
+
+### `protocol.registerFileProtocol(scheme, handler[, completion])`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `filePath` String (optional)
+* `completion` Function (optional)
+  * `error` Error
+
+Registers a protocol of `scheme` that will send the file as a response. The
+`handler` will be called with `handler(request, callback)` when a `request` is
+going to be created with `scheme`. `completion` will be called with
+`completion(null)` when `scheme` is successfully registered or
+`completion(error)` when failed.
+
+To handle the `request`, the `callback` should be called with either the file's
+path or an object that has a `path` property, e.g. `callback(filePath)` or
+`callback({path: filePath})`.
+
+When `callback` is called with nothing, a number, or an object that has an
+`error` property, the `request` will fail with the `error` number you
+specified. For the available error numbers you can use, please see the
+[net error list][net-error].
+
+By default the `scheme` is treated like `http:`, which is parsed differently
+than protocols that follow the "generic URI syntax" like `file:`, so you
+probably want to call `protocol.registerStandardSchemes` to have your scheme
+treated as a standard scheme.
+
+### `protocol.registerBufferProtocol(scheme, handler[, completion])`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `buffer` Buffer (optional)
+* `completion` Function (optional)
+  * `error` Error
+
+Registers a protocol of `scheme` that will send a `Buffer` as a response.
+
+The usage is the same with `registerFileProtocol`, except that the `callback`
+should be called with either a `Buffer` object or an object that has the `data`,
+`mimeType`, and `charset` properties.
+
+Example:
+
+```javascript
+const {protocol} = require('electron')
+
+protocol.registerBufferProtocol('atom', (request, callback) => {
+  callback({mimeType: 'text/html', data: new Buffer('<h5>Response</h5>')})
+}, (error) => {
+  if (error) console.error('Failed to register protocol')
+})
+```
+
+### `protocol.registerStringProtocol(scheme, handler[, completion])`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `data` String (optional)
+* `completion` Function (optional)
+  * `error` Error
+
+Registers a protocol of `scheme` that will send a `String` as a response.
+
+The usage is the same with `registerFileProtocol`, except that the `callback`
+should be called with either a `String` or an object that has the `data`,
+`mimeType`, and `charset` properties.
+
+### `protocol.registerHttpProtocol(scheme, handler[, completion])`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `redirectRequest` Object
+      * `url` String
+      * `method` String
+      * `session` Object (optional)
+      * `uploadData` Object (optional)
+        * `contentType` String - MIME type of the content.
+        * `data` String - Content to be sent.
+* `completion` Function (optional)
+  * `error` Error
+
+Registers a protocol of `scheme` that will send an HTTP request as a response.
+
+The usage is the same with `registerFileProtocol`, except that the `callback`
+should be called with a `redirectRequest` object that has the `url`, `method`,
+`referrer`, `uploadData` and `session` properties.
+
+By default the HTTP request will reuse the current session. If you want the
+request to have a different session you should set `session` to `null`.
+
+For POST requests the `uploadData` object must be provided.
+
+### `protocol.unregisterProtocol(scheme[, completion])`
+
+* `scheme` String
+* `completion` Function (optional)
+  * `error` Error
+
+Unregisters the custom protocol of `scheme`.
+
+### `protocol.isProtocolHandled(scheme, callback)`
+
+* `scheme` String
+* `callback` Function
+  * `error` Error
+
+The `callback` will be called with a boolean that indicates whether there is
+already a handler for `scheme`.
+
+### `protocol.interceptFileProtocol(scheme, handler[, completion])`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `filePath` String
+* `completion` Function (optional)
+  * `error` Error
+
+Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
+which sends a file as a response.
+
+### `protocol.interceptStringProtocol(scheme, handler[, completion])`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `data` String (optional)
+* `completion` Function (optional)
+  * `error` Error
+
+Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
+which sends a `String` as a response.
+
+### `protocol.interceptBufferProtocol(scheme, handler[, completion])`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `buffer` Buffer (optional)
+* `completion` Function (optional)
+  * `error` Error
+
+Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
+which sends a `Buffer` as a response.
+
+### `protocol.interceptHttpProtocol(scheme, handler[, completion])`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `redirectRequest` Object
+      * `url` String
+      * `method` String
+      * `session` Object (optional)
+      * `uploadData` Object (optional)
+        * `contentType` String - MIME type of the content.
+        * `data` String - Content to be sent.
+* `completion` Function (optional)
+  * `error` Error
+
+Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
+which sends a new HTTP request as a response.
+
+### `protocol.uninterceptProtocol(scheme[, completion])`
+
+* `scheme` String
+* `completion` Function (optional)
+  * `error` Error
+
+Remove the interceptor installed for `scheme` and restore its original handler.
+
+[net-error]: https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h
+[file-system-api]: https://developer.mozilla.org/en-US/docs/Web/API/LocalFileSystem

--- a/test/fixtures/electron/docs/api/remote.md
+++ b/test/fixtures/electron/docs/api/remote.md
@@ -140,7 +140,7 @@ The `remote` module has the following methods:
 
 * `module` String
 
-Returns `Object` - The object returned by `require(module)` in the main process.
+Returns `any` - The object returned by `require(module)` in the main process.
 
 ### `remote.getCurrentWindow()`
 

--- a/test/fixtures/electron/docs/api/remote.md
+++ b/test/fixtures/electron/docs/api/remote.md
@@ -1,0 +1,169 @@
+# remote
+
+> Use main process modules from the renderer process.
+
+Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+
+The `remote` module provides a simple way to do inter-process communication
+(IPC) between the renderer process (web page) and the main process.
+
+In Electron, GUI-related modules (such as `dialog`, `menu` etc.) are only
+available in the main process, not in the renderer process. In order to use them
+from the renderer process, the `ipc` module is necessary to send inter-process
+messages to the main process. With the `remote` module, you can invoke methods
+of the main process object without explicitly sending inter-process messages,
+similar to Java's [RMI][rmi]. An example of creating a browser window from a
+renderer process:
+
+```javascript
+const {BrowserWindow} = require('electron').remote
+let win = new BrowserWindow({width: 800, height: 600})
+win.loadURL('https://github.com')
+```
+
+**Note:** For the reverse (access the renderer process from the main process),
+you can use [webContents.executeJavascript](web-contents.md#contentsexecutejavascriptcode-usergesture-callback).
+
+## Remote Objects
+
+Each object (including functions) returned by the `remote` module represents an
+object in the main process (we call it a remote object or remote function).
+When you invoke methods of a remote object, call a remote function, or create
+a new object with the remote constructor (function), you are actually sending
+synchronous inter-process messages.
+
+In the example above, both `BrowserWindow` and `win` were remote objects and
+`new BrowserWindow` didn't create a `BrowserWindow` object in the renderer
+process. Instead, it created a `BrowserWindow` object in the main process and
+returned the corresponding remote object in the renderer process, namely the
+`win` object.
+
+**Note:** Only [enumerable properties][enumerable-properties] which are present
+when the remote object is first referenced are accessible via remote.
+
+**Note:** Arrays and Buffers are copied over IPC when accessed via the `remote`
+module. Modifying them in the renderer process does not modify them in the main
+process and vice versa.
+
+## Lifetime of Remote Objects
+
+Electron makes sure that as long as the remote object in the renderer process
+lives (in other words, has not been garbage collected), the corresponding object
+in the main process will not be released. When the remote object has been
+garbage collected, the corresponding object in the main process will be
+dereferenced.
+
+If the remote object is leaked in the renderer process (e.g. stored in a map but
+never freed), the corresponding object in the main process will also be leaked,
+so you should be very careful not to leak remote objects.
+
+Primary value types like strings and numbers, however, are sent by copy.
+
+## Passing callbacks to the main process
+
+Code in the main process can accept callbacks from the renderer - for instance
+the `remote` module - but you should be extremely careful when using this
+feature.
+
+First, in order to avoid deadlocks, the callbacks passed to the main process
+are called asynchronously. You should not expect the main process to
+get the return value of the passed callbacks.
+
+For instance you can't use a function from the renderer process in an
+`Array.map` called in the main process:
+
+```javascript
+// main process mapNumbers.js
+exports.withRendererCallback = (mapper) => {
+  return [1, 2, 3].map(mapper)
+}
+
+exports.withLocalCallback = () => {
+  return [1, 2, 3].map(x => x + 1)
+}
+```
+
+```javascript
+// renderer process
+const mapNumbers = require('electron').remote.require('./mapNumbers')
+const withRendererCb = mapNumbers.withRendererCallback(x => x + 1)
+const withLocalCb = mapNumbers.withLocalCallback()
+
+console.log(withRendererCb, withLocalCb)
+// [undefined, undefined, undefined], [2, 3, 4]
+```
+
+As you can see, the renderer callback's synchronous return value was not as
+expected, and didn't match the return value of an identical callback that lives
+in the main process.
+
+Second, the callbacks passed to the main process will persist until the
+main process garbage-collects them.
+
+For example, the following code seems innocent at first glance. It installs a
+callback for the `close` event on a remote object:
+
+```javascript
+require('electron').remote.getCurrentWindow().on('close', () => {
+  // window was closed...
+})
+```
+
+But remember the callback is referenced by the main process until you
+explicitly uninstall it. If you do not, each time you reload your window the
+callback will be installed again, leaking one callback for each restart.
+
+To make things worse, since the context of previously installed callbacks has
+been released, exceptions will be raised in the main process when the `close`
+event is emitted.
+
+To avoid this problem, ensure you clean up any references to renderer callbacks
+passed to the main process. This involves cleaning up event handlers, or
+ensuring the main process is explicitly told to deference callbacks that came
+from a renderer process that is exiting.
+
+## Accessing built-in modules in the main process
+
+The built-in modules in the main process are added as getters in the `remote`
+module, so you can use them directly like the `electron` module.
+
+```javascript
+const app = require('electron').remote.app
+console.log(app)
+```
+
+## Methods
+
+The `remote` module has the following methods:
+
+### `remote.require(module)`
+
+* `module` String
+
+Returns `Object` - The object returned by `require(module)` in the main process.
+
+### `remote.getCurrentWindow()`
+
+Returns `BrowserWindow` - The [`BrowserWindow`](browser-window.md) object to which this web page
+belongs.
+
+### `remote.getCurrentWebContents()`
+
+Returns `WebContents` - The [`WebContents`](web-contents.md) object of this web page.
+
+### `remote.getGlobal(name)`
+
+* `name` String
+
+Returns `any` - The global variable of `name` (e.g. `global[name]`) in the main
+process.
+
+## Properties
+
+### `remote.process`
+
+The `process` object in the main process. This is the same as
+`remote.getGlobal('process')` but is cached.
+
+[rmi]: http://en.wikipedia.org/wiki/Java_remote_method_invocation
+[enumerable-properties]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties

--- a/test/fixtures/electron/docs/api/screen.md
+++ b/test/fixtures/electron/docs/api/screen.md
@@ -1,0 +1,121 @@
+# screen
+
+> Retrieve information about screen size, displays, cursor position, etc.
+
+Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+
+You cannot require or use this module until the `ready` event of the `app`
+module is emitted.
+
+`screen` is an [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter).
+
+**Note:** In the renderer / DevTools, `window.screen` is a reserved DOM
+property, so writing `let {screen} = require('electron')` will not work.
+
+An example of creating a window that fills the whole screen:
+
+```javascript
+const electron = require('electron')
+const {app, BrowserWindow} = electron
+
+let win
+
+app.on('ready', () => {
+  const {width, height} = electron.screen.getPrimaryDisplay().workAreaSize
+  win = new BrowserWindow({width, height})
+  win.loadURL('https://github.com')
+})
+```
+
+Another example of creating a window in the external display:
+
+```javascript
+const electron = require('electron')
+const {app, BrowserWindow} = require('electron')
+
+let win
+
+app.on('ready', () => {
+  let displays = electron.screen.getAllDisplays()
+  let externalDisplay = displays.find((display) => {
+    return display.bounds.x !== 0 || display.bounds.y !== 0
+  })
+
+  if (externalDisplay) {
+    win = new BrowserWindow({
+      x: externalDisplay.bounds.x + 50,
+      y: externalDisplay.bounds.y + 50
+    })
+    win.loadURL('https://github.com')
+  }
+})
+```
+
+## Events
+
+The `screen` module emits the following events:
+
+### Event: 'display-added'
+
+Returns:
+
+* `event` Event
+* `newDisplay` [Display](structures/display.md)
+
+Emitted when `newDisplay` has been added.
+
+### Event: 'display-removed'
+
+Returns:
+
+* `event` Event
+* `oldDisplay` [Display](structures/display.md)
+
+Emitted when `oldDisplay` has been removed.
+
+### Event: 'display-metrics-changed'
+
+Returns:
+
+* `event` Event
+* `display` [Display](structures/display.md)
+* `changedMetrics` String[]
+
+Emitted when one or more metrics change in a `display`. The `changedMetrics` is
+an array of strings that describe the changes. Possible changes are `bounds`,
+`workArea`, `scaleFactor` and `rotation`.
+
+## Methods
+
+The `screen` module has the following methods:
+
+### `screen.getCursorScreenPoint()`
+
+Returns `Object`:
+
+* `x` Integer
+* `y` Integer
+
+The current absolute position of the mouse pointer.
+
+### `screen.getPrimaryDisplay()`
+
+Returns `Display` - The primary display.
+
+### `screen.getAllDisplays()`
+
+Returns `Display[]` - An array of displays that are currently available.
+
+### `screen.getDisplayNearestPoint(point)`
+
+* `point` Object
+  * `x` Integer
+  * `y` Integer
+
+Returns `Display` - The display nearest the specified point.
+
+### `screen.getDisplayMatching(rect)`
+
+* `rect` [Rectangle](structures/rectangle.md)
+
+Returns `Display` - The display that most closely intersects the provided bounds.

--- a/test/fixtures/electron/docs/api/session.md
+++ b/test/fixtures/electron/docs/api/session.md
@@ -1,0 +1,689 @@
+# session
+
+> Manage browser sessions, cookies, cache, proxy settings, etc.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+The `session` module can be used to create new `Session` objects.
+
+You can also access the `session` of existing pages by using the `session`
+property of [`WebContents`](web-contents.md), or from the `session` module.
+
+```javascript
+const {BrowserWindow} = require('electron')
+
+let win = new BrowserWindow({width: 800, height: 600})
+win.loadURL('http://github.com')
+
+const ses = win.webContents.session
+console.log(ses.getUserAgent())
+```
+
+## Methods
+
+The `session` module has the following methods:
+
+### `session.fromPartition(partition[, options])`
+
+* `partition` String
+* `options` Object
+  * `cache` Boolean - Whether to enable cache.
+
+Returns `Session` - A session instance from `partition` string. When there is an existing
+`Session` with the same `partition`, it will be returned; othewise a new
+`Session` instance will be created with `options`.
+
+If `partition` starts with `persist:`, the page will use a persistent session
+available to all pages in the app with the same `partition`. if there is no
+`persist:` prefix, the page will use an in-memory session. If the `partition` is
+empty then default session of the app will be returned.
+
+To create a `Session` with `options`, you have to ensure the `Session` with the
+`partition` has never been used before. There is no way to change the `options`
+of an existing `Session` object.
+
+## Properties
+
+The `session` module has the following properties:
+
+### `session.defaultSession`
+
+A `Session` object, the default session object of the app.
+
+## Class: Session
+
+> Get and set properties of a session.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+You can create a `Session` object in the `session` module:
+
+```javascript
+const {session} = require('electron')
+const ses = session.fromPartition('persist:name')
+console.log(ses.getUserAgent())
+```
+
+### Instance Events
+
+The following events are available on instances of `Session`:
+
+#### Event: 'will-download'
+
+* `event` Event
+* `item` [DownloadItem](download-item.md)
+* `webContents` [WebContents](web-contents.md)
+
+Emitted when Electron is about to download `item` in `webContents`.
+
+Calling `event.preventDefault()` will cancel the download and `item` will not be
+available from next tick of the process.
+
+```javascript
+const {session} = require('electron')
+session.defaultSession.on('will-download', (event, item, webContents) => {
+  event.preventDefault()
+  require('request')(item.getURL(), (data) => {
+    require('fs').writeFileSync('/somewhere', data)
+  })
+})
+```
+
+### Instance Methods
+
+The following methods are available on instances of `Session`:
+
+#### `ses.getCacheSize(callback)`
+
+* `callback` Function
+  * `size` Integer - Cache size used in bytes.
+
+Returns the session's current cache size.
+
+#### `ses.clearCache(callback)`
+
+* `callback` Function - Called when operation is done
+
+Clears the session’s HTTP cache.
+
+#### `ses.clearStorageData([options, callback])`
+
+* `options` Object (optional)
+  * `origin` String - Should follow `window.location.origin`’s representation
+    `scheme://host:port`.
+  * `storages` String[] - The types of storages to clear, can contain:
+    `appcache`, `cookies`, `filesystem`, `indexdb`, `local storage`,
+    `shadercache`, `websql`, `serviceworkers`
+  * `quotas` String[] - The types of quotas to clear, can contain:
+    `temporary`, `persistent`, `syncable`.
+* `callback` Function (optional) - Called when operation is done.
+
+Clears the data of web storages.
+
+#### `ses.flushStorageData()`
+
+Writes any unwritten DOMStorage data to disk.
+
+#### `ses.setProxy(config, callback)`
+
+* `config` Object
+  * `pacScript` String - The URL associated with the PAC file.
+  * `proxyRules` String - Rules indicating which proxies to use.
+  * `proxyBypassRules` String - Rules indicating which URLs should
+    bypass the proxy settings.
+* `callback` Function - Called when operation is done.
+
+Sets the proxy settings.
+
+When `pacScript` and `proxyRules` are provided together, the `proxyRules`
+option is ignored and `pacScript` configuration is applied.
+
+The `proxyRules` has to follow the rules below:
+
+```
+proxyRules = schemeProxies[";"<schemeProxies>]
+schemeProxies = [<urlScheme>"="]<proxyURIList>
+urlScheme = "http" | "https" | "ftp" | "socks"
+proxyURIList = <proxyURL>[","<proxyURIList>]
+proxyURL = [<proxyScheme>"://"]<proxyHost>[":"<proxyPort>]
+```
+
+For example:
+
+* `http=foopy:80;ftp=foopy2` - Use HTTP proxy `foopy:80` for `http://` URLs, and
+  HTTP proxy `foopy2:80` for `ftp://` URLs.
+* `foopy:80` - Use HTTP proxy `foopy:80` for all URLs.
+* `foopy:80,bar,direct://` - Use HTTP proxy `foopy:80` for all URLs, failing
+  over to `bar` if `foopy:80` is unavailable, and after that using no proxy.
+* `socks4://foopy` - Use SOCKS v4 proxy `foopy:1080` for all URLs.
+* `http=foopy,socks5://bar.com` - Use HTTP proxy `foopy` for http URLs, and fail
+  over to the SOCKS5 proxy `bar.com` if `foopy` is unavailable.
+* `http=foopy,direct://` - Use HTTP proxy `foopy` for http URLs, and use no
+  proxy if `foopy` is unavailable.
+* `http=foopy;socks=foopy2` -  Use HTTP proxy `foopy` for http URLs, and use
+  `socks4://foopy2` for all other URLs.
+
+The `proxyBypassRules` is a comma separated list of rules described below:
+
+* `[ URL_SCHEME "://" ] HOSTNAME_PATTERN [ ":" <port> ]`
+
+   Match all hostnames that match the pattern HOSTNAME_PATTERN.
+
+   Examples:
+     "foobar.com", "*foobar.com", "*.foobar.com", "*foobar.com:99",
+     "https://x.*.y.com:99"
+
+ * `"." HOSTNAME_SUFFIX_PATTERN [ ":" PORT ]`
+
+   Match a particular domain suffix.
+
+   Examples:
+     ".google.com", ".com", "http://.google.com"
+
+* `[ SCHEME "://" ] IP_LITERAL [ ":" PORT ]`
+
+   Match URLs which are IP address literals.
+
+   Examples:
+     "127.0.1", "[0:0::1]", "[::1]", "http://[::1]:99"
+
+*  `IP_LITERAL "/" PREFIX_LENGHT_IN_BITS`
+
+   Match any URL that is to an IP literal that falls between the
+   given range. IP range is specified using CIDR notation.
+
+   Examples:
+     "192.168.1.1/16", "fefe:13::abc/33".
+
+*  `<local>`
+
+   Match local addresses. The meaning of `<local>` is whether the
+   host matches one of: "127.0.0.1", "::1", "localhost".
+
+### `ses.resolveProxy(url, callback)`
+
+* `url` URL
+* `callback` Function
+  * `proxy` Object
+
+Resolves the proxy information for `url`. The `callback` will be called with
+`callback(proxy)` when the request is performed.
+
+#### `ses.setDownloadPath(path)`
+
+* `path` String - The download location
+
+Sets download saving directory. By default, the download directory will be the
+`Downloads` under the respective app folder.
+
+#### `ses.enableNetworkEmulation(options)`
+
+* `options` Object
+  * `offline` Boolean (optional) - Whether to emulate network outage. Defaults
+    to false.
+  * `latency` Double (optional) - RTT in ms. Defaults to 0 which will disable
+    latency throttling.
+  * `downloadThroughput` Double (optional) - Download rate in Bps. Defaults to 0
+    which will disable download throttling.
+  * `uploadThroughput` Double (optional) - Upload rate in Bps. Defaults to 0
+    which will disable upload throttling.
+
+Emulates network with the given configuration for the `session`.
+
+```javascript
+// To emulate a GPRS connection with 50kbps throughput and 500 ms latency.
+window.webContents.session.enableNetworkEmulation({
+  latency: 500,
+  downloadThroughput: 6400,
+  uploadThroughput: 6400
+})
+
+// To emulate a network outage.
+window.webContents.session.enableNetworkEmulation({offline: true})
+```
+
+#### `ses.disableNetworkEmulation()`
+
+Disables any network emulation already active for the `session`. Resets to
+the original network configuration.
+
+#### `ses.setCertificateVerifyProc(proc)`
+
+* `proc` Function
+  * `hostname` String
+  * `certificate` [Certificate](structures/certificate.md)
+  * `callback` Function
+    * `isTrusted` Boolean - Determines if the certificate should be trusted
+
+Sets the certificate verify proc for `session`, the `proc` will be called with
+`proc(hostname, certificate, callback)` whenever a server certificate
+verification is requested. Calling `callback(true)` accepts the certificate,
+calling `callback(false)` rejects it.
+
+Calling `setCertificateVerifyProc(null)` will revert back to default certificate
+verify proc.
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow()
+
+win.webContents.session.setCertificateVerifyProc((hostname, cert, callback) => {
+  callback(hostname === 'github.com')
+})
+```
+
+#### `ses.setPermissionRequestHandler(handler)`
+
+* `handler` Function
+  * `webContents` Object - [WebContents](web-contents.md) requesting the permission.
+  * `permission` String - Enum of 'media', 'geolocation', 'notifications', 'midiSysex',
+    'pointerLock', 'fullscreen', 'openExternal'.
+  * `callback` Function
+    * `permissionGranted` Boolean - Allow or deny the permission
+
+Sets the handler which can be used to respond to permission requests for the `session`.
+Calling `callback(true)` will allow the permission and `callback(false)` will reject it.
+
+```javascript
+const {session} = require('electron')
+session.fromPartition('some-partition').setPermissionRequestHandler((webContents, permission, callback) => {
+  if (webContents.getURL() === 'some-host' && permission === 'notifications') {
+    return callback(false) // denied.
+  }
+
+  callback(true)
+})
+```
+
+#### `ses.clearHostResolverCache([callback])`
+
+* `callback` Function (optional) - Called when operation is done.
+
+Clears the host resolver cache.
+
+#### `ses.allowNTLMCredentialsForDomains(domains)`
+
+* `domains` String - A comma-seperated list of servers for which
+  integrated authentication is enabled.
+
+Dynamically sets whether to always send credentials for HTTP NTLM or Negotiate
+authentication.
+
+```javascript
+const {session} = require('electron')
+// consider any url ending with `example.com`, `foobar.com`, `baz`
+// for integrated authentication.
+session.defaultSession.allowNTLMCredentialsForDomains('*example.com, *foobar.com, *baz')
+
+// consider all urls for integrated authentication.
+session.defaultSession.allowNTLMCredentialsForDomains('*')
+```
+
+#### `ses.setUserAgent(userAgent[, acceptLanguages])`
+
+* `userAgent` String
+* `acceptLanguages` String (optional)
+
+Overrides the `userAgent` and `acceptLanguages` for this session.
+
+The `acceptLanguages` must a comma separated ordered list of language codes, for
+example `"en-US,fr,de,ko,zh-CN,ja"`.
+
+This doesn't affect existing `WebContents`, and each `WebContents` can use
+`webContents.setUserAgent` to override the session-wide user agent.
+
+#### `ses.getUserAgent()`
+
+Returns `String` - The user agent for this session.
+
+#### `ses.getBlobData(identifier, callback)`
+
+* `identifier` String - Valid UUID.
+* `callback` Function
+  * `result` Buffer - Blob data.
+
+Returns `Blob` - The blob data associated with the `identifier`.
+
+### Instance Properties
+
+The following properties are available on instances of `Session`:
+
+#### `ses.cookies`
+
+A Cookies object for this session.
+
+#### `ses.webRequest`
+
+A WebRequest object for this session.
+
+#### `ses.protocol`
+
+A Protocol object (an instance of [protocol](protocol.md) module) for this session.
+
+```javascript
+const {app, session} = require('electron')
+const path = require('path')
+
+app.on('ready', function () {
+  const protocol = session.fromPartition('some-partition').protocol
+  protocol.registerFileProtocol('atom', function (request, callback) {
+    var url = request.url.substr(7)
+    callback({path: path.normalize(`${__dirname}/${url}`)})
+  }, function (error) {
+    if (error) console.error('Failed to register protocol')
+  })
+})
+```
+
+## Class: Cookies
+
+> Query and modify a session's cookies.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+Instances of the `Cookies` class are accessed by using `cookies` property of
+a `Session`.
+
+For example:
+
+```javascript
+const {session} = require('electron')
+
+// Query all cookies.
+session.defaultSession.cookies.get({}, (error, cookies) => {
+  console.log(error, cookies)
+})
+
+// Query all cookies associated with a specific url.
+session.defaultSession.cookies.get({url: 'http://www.github.com'}, (error, cookies) => {
+  console.log(error, cookies)
+})
+
+// Set a cookie with the given cookie data;
+// may overwrite equivalent cookies if they exist.
+const cookie = {url: 'http://www.github.com', name: 'dummy_name', value: 'dummy'}
+session.defaultSession.cookies.set(cookie, (error) => {
+  if (error) console.error(error)
+})
+```
+
+### Instance Events
+
+The following events are available on instances of `Cookies`:
+
+#### Event: 'changed'
+
+* `event` Event
+* `cookie` [Cookie](structures/cookie.md) - The cookie that was changed
+* `cause` String - The cause of the change with one of the following values:
+  * `explicit` - The cookie was changed directly by a consumer's action.
+  * `overwrite` - The cookie was automatically removed due to an insert
+    operation that overwrote it.
+  * `expired` - The cookie was automatically removed as it expired.
+  * `evicted` - The cookie was automatically evicted during garbage collection.
+  * `expired-overwrite` - The cookie was overwritten with an already-expired
+    expiration date.
+* `removed` Boolean - `true` if the cookie was removed, `false` otherwise.
+
+Emitted when a cookie is changed because it was added, edited, removed, or
+expired.
+
+### Instance Methods
+
+The following methods are available on instances of `Cookies`:
+
+#### `cookies.get(filter, callback)`
+
+* `filter` Object
+  * `url` String (optional) - Retrieves cookies which are associated with
+    `url`. Empty implies retrieving cookies of all urls.
+  * `name` String (optional) - Filters cookies by name.
+  * `domain` String (optional) - Retrieves cookies whose domains match or are
+    subdomains of `domains`
+  * `path` String (optional) - Retrieves cookies whose path matches `path`.
+  * `secure` Boolean (optional) - Filters cookies by their Secure property.
+  * `session` Boolean (optional) - Filters out session or persistent cookies.
+* `callback` Function
+  * `error` Error
+  * `cookies` Cookies[]
+
+Sends a request to get all cookies matching `details`, `callback` will be called
+with `callback(error, cookies)` on complete.
+
+`cookies` is an Array of [`cookie`](structures/cookie.md) objects.
+
+#### `cookies.set(details, callback)`
+
+* `details` Object
+  * `url` String - The url to associate the cookie with.
+  * `name` String - The name of the cookie. Empty by default if omitted.
+  * `value` String - The value of the cookie. Empty by default if omitted.
+  * `domain` String - The domain of the cookie. Empty by default if omitted.
+  * `path` String - The path of the cookie. Empty by default if omitted.
+  * `secure` Boolean - Whether the cookie should be marked as Secure. Defaults to
+    false.
+  * `httpOnly` Boolean - Whether the cookie should be marked as HTTP only.
+    Defaults to false.
+  * `expirationDate` Double -	The expiration date of the cookie as the number of
+    seconds since the UNIX epoch. If omitted then the cookie becomes a session
+    cookie and will not be retained between sessions.
+* `callback` Function
+  * `error` Error
+
+Sets a cookie with `details`, `callback` will be called with `callback(error)`
+on complete.
+
+#### `cookies.remove(url, name, callback)`
+
+* `url` String - The URL associated with the cookie.
+* `name` String - The name of cookie to remove.
+* `callback` Function
+
+Removes the cookies matching `url` and `name`, `callback` will called with
+`callback()` on complete.
+
+## Class: WebRequest
+
+> Intercept and modify the contents of a request at various stages of its lifetime.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+Instances of the `WebRequest` class are accessed by using the `webRequest`
+property of a `Session`.
+
+The methods of `WebRequest` accept an optional `filter` and a `listener`. The
+`listener` will be called with `listener(details)` when the API's event has
+happened. The `details` object describes the request. Passing `null`
+as `listener` will unsubscribe from the event.
+
+The `filter` object has a `urls` property which is an Array of URL
+patterns that will be used to filter out the requests that do not match the URL
+patterns. If the `filter` is omitted then all requests will be matched.
+
+For certain events the `listener` is passed with a `callback`, which should be
+called with a `response` object when `listener` has done its work.
+
+An example of adding `User-Agent` header for requests:
+
+```javascript
+const {session} = require('electron')
+
+// Modify the user agent for all requests to the following urls.
+const filter = {
+  urls: ['https://*.github.com/*', '*://electron.github.io']
+}
+
+session.defaultSession.webRequest.onBeforeSendHeaders(filter, (details, callback) => {
+  details.requestHeaders['User-Agent'] = 'MyAgent'
+  callback({cancel: false, requestHeaders: details.requestHeaders})
+})
+```
+
+### Instance Methods
+
+The following methods are available on instances of `WebRequest`:
+
+#### `webRequest.onBeforeRequest([filter, ]listener)`
+
+* `filter` Object
+* `listener` Function
+  * `details` Object
+    * `id` Integer
+    * `url` String
+    * `method` String
+    * `resourceType` String
+    * `timestamp` Double
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `response` Object
+      * `cancel` Boolean (optional)
+      * `redirectURL` String (optional) - The original request is prevented from
+        being sent or completed and is instead redirected to the given URL.
+
+The `listener` will be called with `listener(details, callback)` when a request
+is about to occur.
+
+The `uploadData` is an array of `UploadData` objects.
+
+The `callback` has to be called with an `response` object.
+
+#### `webRequest.onBeforeSendHeaders([filter, ]listener)`
+
+* `filter` Object
+* `listener` Function
+
+The `listener` will be called with `listener(details, callback)` before sending
+an HTTP request, once the request headers are available. This may occur after a
+TCP connection is made to the server, but before any http data is sent.
+
+* `details` Object
+  * `id` Integer
+  * `url` String
+  * `method` String
+  * `resourceType` String
+  * `timestamp` Double
+  * `requestHeaders` Object
+* `callback` Function
+  * `response` Object
+    * `cancel` Boolean (optional)
+    * `requestHeaders` Object (optional) - When provided, request will be made
+      with these headers.
+
+The `callback` has to be called with an `response` object.
+
+#### `webRequest.onSendHeaders([filter, ]listener)`
+
+* `filter` Object
+* `listener` Function
+  * `details` Object
+    * `id` Integer
+    * `url` String
+    * `method` String
+    * `resourceType` String
+    * `timestamp` Double
+    * `requestHeaders` Object
+
+The `listener` will be called with `listener(details)` just before a request is
+going to be sent to the server, modifications of previous `onBeforeSendHeaders`
+response are visible by the time this listener is fired.
+
+#### `webRequest.onHeadersReceived([filter, ]listener)`
+
+* `filter` Object
+* `listener` Function
+
+The `listener` will be called with `listener(details, callback)` when HTTP
+response headers of a request have been received.
+
+* `details` Object
+  * `id` String
+  * `url` String
+  * `method` String
+  * `resourceType` String
+  * `timestamp` Double
+  * `statusLine` String
+  * `statusCode` Integer
+  * `responseHeaders` Object
+* `callback` Function
+  * `response` Object
+    * `cancel` Boolean
+    * `responseHeaders` Object (optional) - When provided, the server is assumed
+      to have responded with these headers.
+    * `statusLine` String (optional) - Should be provided when overriding
+      `responseHeaders` to change header status otherwise original response
+      header's status will be used.
+
+The `callback` has to be called with an `response` object.
+
+#### `webRequest.onResponseStarted([filter, ]listener)`
+
+* `filter` Object
+* `listener` Function
+  * `details` Object
+    * `id` Integer
+    * `url` String
+    * `method` String
+    * `resourceType` String
+    * `timestamp` Double
+    * `responseHeaders` Object
+    * `fromCache` Boolean - Indicates whether the response was fetched from disk
+      cache.
+    * `statusCode` Integer
+    * `statusLine` String
+
+The `listener` will be called with `listener(details)` when first byte of the
+response body is received. For HTTP requests, this means that the status line
+and response headers are available.
+
+#### `webRequest.onBeforeRedirect([filter, ]listener)`
+
+* `filter` Object
+* `listener` Function
+  * `details` Object
+    * `id` String
+    * `url` String
+    * `method` String
+    * `resourceType` String
+    * `timestamp` Double
+    * `redirectURL` String
+    * `statusCode` Integer
+    * `ip` String (optional) - The server IP address that the request was
+      actually sent to.
+    * `fromCache` Boolean
+    * `responseHeaders` Object
+
+The `listener` will be called with `listener(details)` when a server initiated
+redirect is about to occur.
+
+#### `webRequest.onCompleted([filter, ]listener)`
+
+* `filter` Object
+* `listener` Function
+  * `details` Object
+    * `id` Integer
+    * `url` String
+    * `method` String
+    * `resourceType` String
+    * `timestamp` Double
+    * `responseHeaders` Object
+    * `fromCache` Boolean
+    * `statusCode` Integer
+    * `statusLine` String
+
+The `listener` will be called with `listener(details)` when a request is
+completed.
+
+#### `webRequest.onErrorOccurred([filter, ]listener)`
+
+* `filter` Object
+* `listener` Function
+  * `details` Object
+    * `id` Integer
+    * `url` String
+    * `method` String
+    * `resourceType` String
+    * `timestamp` Double
+    * `fromCache` Boolean
+    * `error` String - The error description.
+
+The `listener` will be called with `listener(details)` when an error occurs.

--- a/test/fixtures/electron/docs/api/shell.md
+++ b/test/fixtures/electron/docs/api/shell.md
@@ -1,0 +1,83 @@
+# shell
+
+> Manage files and URLs using their default applications.
+
+Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+
+The `shell` module provides functions related to desktop integration.
+
+An example of opening a URL in the user's default browser:
+
+```javascript
+const {shell} = require('electron')
+
+shell.openExternal('https://github.com')
+```
+
+## Methods
+
+The `shell` module has the following methods:
+
+### `shell.showItemInFolder(fullPath)`
+
+* `fullPath` String
+
+Returns `Boolean` - Whether the item was successfully shown
+
+Show the given file in a file manager. If possible, select the file.
+
+### `shell.openItem(fullPath)`
+
+* `fullPath` String
+
+Returns `Boolean` - Whether the item was successfully opened.
+
+Open the given file in the desktop's default manner.
+
+### `shell.openExternal(url[, options])`
+
+* `url` String
+* `options` Object (optional) _macOS_
+  * `activate` Boolean - `true` to bring the opened application to the
+    foreground. The default is `true`.
+
+Returns `Boolean` - Whether an application was available to open the URL.
+
+Open the given external protocol URL in the desktop's default manner. (For
+example, mailto: URLs in the user's default mail agent).
+
+### `shell.moveItemToTrash(fullPath)`
+
+* `fullPath` String
+
+Returns `Boolean` - Whether the item was successfully moved to the trash
+
+Move the given file to trash and returns a boolean status for the operation.
+
+### `shell.beep()`
+
+Play the beep sound.
+
+### `shell.writeShortcutLink(shortcutPath[, operation], options)` _Windows_
+
+* `shortcutPath` String
+* `operation` String (optional) - Default is `create`, can be one of following:
+  * `create` - Creates a new shortcut, overwriting if necessary.
+  * `update` - Updates specified properties only on an existing shortcut.
+  * `replace` - Overwrites an existing shortcut, fails if the shortcut doesn't
+    exist.
+* `options` [ShortcutDetails](structures/shortcut-details.md)
+
+Returns `Boolean` - Whether the shortcut was created successfully
+
+Creates or updates a shortcut link at `shortcutPath`.
+
+### `shell.readShortcutLink(shortcutPath)` _Windows_
+
+* `shortcutPath` String
+
+Returns [`ShortcutDetails`](structures/shortcut-details.md)
+
+Resolves the shortcut link at `shortcutPath`.
+
+An exception will be thrown when any error happens.

--- a/test/fixtures/electron/docs/api/structures/bluetooth-device.md
+++ b/test/fixtures/electron/docs/api/structures/bluetooth-device.md
@@ -1,0 +1,4 @@
+# BluetoothDevice Object
+
+* `deviceName` String
+* `deviceId` String

--- a/test/fixtures/electron/docs/api/structures/certificate.md
+++ b/test/fixtures/electron/docs/api/structures/certificate.md
@@ -1,0 +1,9 @@
+# Certificate Object
+
+* `data` String - PEM encoded data
+* `issuerName` String - Issuer's Common Name
+* `subjectName` String - Subject's Common Name
+* `serialNumber` String - Hex value represented string
+* `validStart` Number - Start date of the certificate being valid in seconds
+* `validExpiry` Number - End date of the certificate being valid in seconds
+* `fingerprint` String - Fingerprint of the certificate

--- a/test/fixtures/electron/docs/api/structures/cookie.md
+++ b/test/fixtures/electron/docs/api/structures/cookie.md
@@ -1,0 +1,14 @@
+# Cookie Object
+
+* `name` String - The name of the cookie.
+* `value` String - The value of the cookie.
+* `domain` String - The domain of the cookie.
+* `hostOnly` String - Whether the cookie is a host-only cookie.
+* `path` String - The path of the cookie.
+* `secure` Boolean - Whether the cookie is marked as secure.
+* `httpOnly` Boolean - Whether the cookie is marked as HTTP only.
+* `session` Boolean - Whether the cookie is a session cookie or a persistent
+  cookie with an expiration date.
+* `expirationDate` Double (optional) - The expiration date of the cookie as
+  the number of seconds since the UNIX epoch. Not provided for session
+  cookies.

--- a/test/fixtures/electron/docs/api/structures/crash-report.md
+++ b/test/fixtures/electron/docs/api/structures/crash-report.md
@@ -1,0 +1,4 @@
+# CrashReport Object
+
+* `date` String
+* `ID` Integer

--- a/test/fixtures/electron/docs/api/structures/desktop-capturer-source.md
+++ b/test/fixtures/electron/docs/api/structures/desktop-capturer-source.md
@@ -1,0 +1,14 @@
+# DesktopCapturerSource Object
+
+* `id` String - The identifier of a window or screen that can be used as a
+  `chromeMediaSourceId` constraint when calling
+  [`navigator.webkitGetUserMedia`]. The format of the identifier will be
+  `window:XX` or `screen:XX`, where `XX` is a random generated number.
+* `name` String - A screen source will be named either `Entire Screen` or
+  `Screen <index>`, while the name of a window source will match the window
+  title.
+* `thumbnail` [NativeImage](../native-image.md) - A thumbnail image. **Note:**
+  There is no guarantee that the size of the thumbnail is the same as the
+  `thumbnailSize` specified in the `options` passed to
+  `desktopCapturer.getSources`. The actual size depends on the scale of the
+  screen or window.

--- a/test/fixtures/electron/docs/api/structures/display.md
+++ b/test/fixtures/electron/docs/api/structures/display.md
@@ -1,0 +1,19 @@
+# Display Object
+
+* `id` Number - Unique identifier associated with the display.
+* `rotation` Number - Can be 0, 90, 180, 270, represents screen rotation in
+  clock-wise degrees.
+* `scaleFactor` Number - Output device's pixel scale factor.
+* `touchSupport` String - Can be `available`, `unavailable`, `unknown`.
+* `bounds` [Rectangle](rectangle.md)
+* `size` Object
+  * `height` Number
+  * `width` Number
+* `workArea` [Rectangle](rectangle.md)
+* `workAreaSize` Object
+  * `height` Number
+  * `width` Number
+
+The `Display` object represents a physical display connected to the system. A
+fake `Display` may exist on a headless system, or a `Display` may correspond to
+a remote, virtual display.

--- a/test/fixtures/electron/docs/api/structures/file-filter.md
+++ b/test/fixtures/electron/docs/api/structures/file-filter.md
@@ -1,0 +1,4 @@
+# FileFilter Object
+
+* `name` String
+* `extensions` String[]

--- a/test/fixtures/electron/docs/api/structures/jump-list-category.md
+++ b/test/fixtures/electron/docs/api/structures/jump-list-category.md
@@ -1,0 +1,21 @@
+# JumpListCategory Object
+
+* `type` String - One of the following:
+  * `tasks` - Items in this category will be placed into the standard `Tasks`
+    category. There can be only one such category, and it will always be
+    displayed at the bottom of the Jump List.
+  * `frequent` - Displays a list of files frequently opened by the app, the
+    name of the category and its items are set by Windows.
+  * `recent` - Displays a list of files recently opened by the app, the name
+    of the category and its items are set by Windows. Items may be added to
+    this category indirectly using `app.addRecentDocument(path)`.
+  * `custom` - Displays tasks or file links, `name` must be set by the app.
+* `name` String - Must be set if `type` is `custom`, otherwise it should be
+  omitted.
+* `items` JumpListItem[] - Array of [`JumpListItem`](jump-list-item.md) objects if `type` is `tasks` or
+  `custom`, otherwise it should be omitted.
+
+**Note:** If a `JumpListCategory` object has neither the `type` nor the `name`
+property set then its `type` is assumed to be `tasks`. If the `name` property
+is set but the `type` property is omitted then the `type` is assumed to be
+`custom`.

--- a/test/fixtures/electron/docs/api/structures/jump-list-category.md
+++ b/test/fixtures/electron/docs/api/structures/jump-list-category.md
@@ -10,9 +10,9 @@
     of the category and its items are set by Windows. Items may be added to
     this category indirectly using `app.addRecentDocument(path)`.
   * `custom` - Displays tasks or file links, `name` must be set by the app.
-* `name` String - Must be set if `type` is `custom`, otherwise it should be
+* `name` String - (optional) Must be set if `type` is `custom`, otherwise it should be
   omitted.
-* `items` JumpListItem[] - Array of [`JumpListItem`](jump-list-item.md) objects if `type` is `tasks` or
+* `items` JumpListItem[] - (optional) Array of [`JumpListItem`](jump-list-item.md) objects if `type` is `tasks` or
   `custom`, otherwise it should be omitted.
 
 **Note:** If a `JumpListCategory` object has neither the `type` nor the `name`

--- a/test/fixtures/electron/docs/api/structures/jump-list-item.md
+++ b/test/fixtures/electron/docs/api/structures/jump-list-item.md
@@ -1,0 +1,28 @@
+# JumpListItem Object
+
+* `type` String - One of the following:
+  * `task` - A task will launch an app with specific arguments.
+  * `separator` - Can be used to separate items in the standard `Tasks`
+    category.
+  * `file` - A file link will open a file using the app that created the
+    Jump List, for this to work the app must be registered as a handler for
+    the file type (though it doesn't have to be the default handler).
+* `path` String - Path of the file to open, should only be set if `type` is
+  `file`.
+* `program` String - Path of the program to execute, usually you should
+  specify `process.execPath` which opens the current program. Should only be
+  set if `type` is `task`.
+* `args` String - The command line arguments when `program` is executed. Should
+  only be set if `type` is `task`.
+* `title` String - The text to be displayed for the item in the Jump List.
+  Should only be set if `type` is `task`.
+* `description` String - Description of the task (displayed in a tooltip).
+  Should only be set if `type` is `task`.
+* `iconPath` String - The absolute path to an icon to be displayed in a
+  Jump List, which can be an arbitrary resource file that contains an icon
+  (e.g. `.ico`, `.exe`, `.dll`). You can usually specify `process.execPath` to
+  show the program icon.
+* `iconIndex` Number - The index of the icon in the resource file. If a
+  resource file contains multiple icons this value can be used to specify the
+  zero-based index of the icon that should be displayed for this task. If a
+  resource file contains only one icon, this property should be set to zero.

--- a/test/fixtures/electron/docs/api/structures/jump-list-item.md
+++ b/test/fixtures/electron/docs/api/structures/jump-list-item.md
@@ -7,16 +7,16 @@
   * `file` - A file link will open a file using the app that created the
     Jump List, for this to work the app must be registered as a handler for
     the file type (though it doesn't have to be the default handler).
-* `path` String - Path of the file to open, should only be set if `type` is
+* `path` String - (optional) Path of the file to open, should only be set if `type` is
   `file`.
-* `program` String - Path of the program to execute, usually you should
+* `program` String - (optional) Path of the program to execute, usually you should
   specify `process.execPath` which opens the current program. Should only be
   set if `type` is `task`.
-* `args` String - The command line arguments when `program` is executed. Should
+* `args` String - (optional) The command line arguments when `program` is executed. Should
   only be set if `type` is `task`.
-* `title` String - The text to be displayed for the item in the Jump List.
+* `title` String - (optional) The text to be displayed for the item in the Jump List.
   Should only be set if `type` is `task`.
-* `description` String - Description of the task (displayed in a tooltip).
+* `description` String - (optional) Description of the task (displayed in a tooltip).
   Should only be set if `type` is `task`.
 * `iconPath` String - The absolute path to an icon to be displayed in a
   Jump List, which can be an arbitrary resource file that contains an icon

--- a/test/fixtures/electron/docs/api/structures/memory-usage-details.md
+++ b/test/fixtures/electron/docs/api/structures/memory-usage-details.md
@@ -1,0 +1,8 @@
+# MemoryUsageDetails Object
+
+* `count` Number
+* `size` Number
+* `liveSize` Number
+* `decodedSize` Number
+* `purgedSize` Number
+* `purgeableSize` Number

--- a/test/fixtures/electron/docs/api/structures/rectangle.md
+++ b/test/fixtures/electron/docs/api/structures/rectangle.md
@@ -1,0 +1,6 @@
+# Rectangle Object
+
+* `x` Number - The x coordinate of the origin of the rectangle
+* `y` Number - The y coordinate of the origin of the rectangle
+* `width` Number
+* `height` Number

--- a/test/fixtures/electron/docs/api/structures/shortcut-details.md
+++ b/test/fixtures/electron/docs/api/structures/shortcut-details.md
@@ -1,0 +1,15 @@
+# ShortcutDetails Object
+
+* `target` String - The target to launch from this shortcut.
+* `cwd` String (optional) - The working directory. Default is empty.
+* `args` String (optional) - The arguments to be applied to `target` when
+launching from this shortcut. Default is empty.
+* `description` String (optional) - The description of the shortcut. Default
+is empty.
+* `icon` String (optional) - The path to the icon, can be a DLL or EXE. `icon`
+and `iconIndex` have to be set together. Default is empty, which uses the
+target's icon.
+* `iconIndex` Number (optional) - The resource ID of icon when `icon` is a
+DLL or EXE. Default is 0.
+* `appUserModelId` String (optional) - The Application User Model ID. Default
+is empty.

--- a/test/fixtures/electron/docs/api/structures/task.md
+++ b/test/fixtures/electron/docs/api/structures/task.md
@@ -1,0 +1,14 @@
+# Task Object
+
+* `program` String - Path of the program to execute, usually you should
+  specify `process.execPath` which opens the current program.
+* `arguments` String - The command line arguments when `program` is
+  executed.
+* `title` String - The string to be displayed in a JumpList.
+* `description` String - Description of this task.
+* `iconPath` String - The absolute path to an icon to be displayed in a
+  JumpList, which can be an arbitrary resource file that contains an icon. You
+  can usually specify `process.execPath` to show the icon of the program.
+* `iconIndex` Number - The icon index in the icon file. If an icon file
+  consists of two or more icons, set this value to identify the icon. If an
+  icon file consists of one icon, this value is 0.

--- a/test/fixtures/electron/docs/api/structures/thumbar-button.md
+++ b/test/fixtures/electron/docs/api/structures/thumbar-button.md
@@ -1,0 +1,21 @@
+# ThumbarButton Object
+
+* `icon` [NativeImage](../native-image.md) - The icon showing in thumbnail
+  toolbar.
+* `click` Function
+* `tooltip` String (optional) - The text of the button's tooltip.
+* `flags` String[] (optional) - Control specific states and behaviors of the
+  button. By default, it is `['enabled']`.
+
+The `flags` is an array that can include following `String`s:
+
+* `enabled` - The button is active and available to the user.
+* `disabled` - The button is disabled. It is present, but has a visual state
+  indicating it will not respond to user action.
+* `dismissonclick` - When the button is clicked, the thumbnail window closes
+  immediately.
+* `nobackground` - Do not draw a button border, use only the image.
+* `hidden` - The button is not shown to the user.
+* `noninteractive` - The button is enabled but not interactive; no pressed
+  button state is drawn. This value is intended for instances where the button
+  is used in a notification.

--- a/test/fixtures/electron/docs/api/structures/upload-data.md
+++ b/test/fixtures/electron/docs/api/structures/upload-data.md
@@ -1,0 +1,6 @@
+# UploadData Object
+
+* `bytes` Buffer - Content being sent.
+* `file` String - Path of file being uploaded.
+* `blobUUID` String - UUID of blob data. Use [ses.getBlobData](../session.md#sesgetblobdataidentifier-callback) method
+  to retrieve the data.

--- a/test/fixtures/electron/docs/api/synopsis.md
+++ b/test/fixtures/electron/docs/api/synopsis.md
@@ -1,0 +1,95 @@
+# Synopsis
+
+> How to use Node.js and Electron APIs.
+
+All of [Node.js's built-in modules](https://nodejs.org/api/) are available in
+Electron and third-party node modules also fully supported as well (including
+the [native modules](../tutorial/using-native-node-modules.md)).
+
+Electron also provides some extra built-in modules for developing native
+desktop applications. Some modules are only available in the main process, some
+are only available in the renderer process (web page), and some can be used in
+both processes.
+
+The basic rule is: if a module is [GUI][gui] or low-level system related, then
+it should be only available in the main process. You need to be familiar with
+the concept of [main process vs. renderer process](../tutorial/quick-start.md#main-process)
+scripts to be able to use those modules.
+
+The main process script is just like a normal Node.js script:
+
+```javascript
+const {app, BrowserWindow} = require('electron')
+let win = null
+
+app.on('ready', () => {
+  win = new BrowserWindow({width: 800, height: 600})
+  win.loadURL('https://github.com')
+})
+```
+
+The renderer process is no different than a normal web page, except for the
+extra ability to use node modules:
+
+```html
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+  const {app} = require('electron').remote
+  console.log(app.getVersion())
+</script>
+</body>
+</html>
+```
+
+To run your app, read [Run your app](../tutorial/quick-start.md#run-your-app).
+
+## Destructuring assignment
+
+As of 0.37, you can use
+[destructuring assignment][destructuring-assignment] to make it easier to use
+built-in modules.
+
+```javascript
+const {app, BrowserWindow} = require('electron')
+
+let win
+
+app.on('ready', () => {
+  win = new BrowserWindow()
+  win.loadURL('https://github.com')
+})
+```
+
+If you need the entire `electron` module, you can require it and then using
+destructuring to access the individual modules from `electron`.
+
+```javascript
+const electron = require('electron')
+const {app, BrowserWindow} = electron
+
+let win
+
+app.on('ready', () => {
+  win = new BrowserWindow()
+  win.loadURL('https://github.com')
+})
+```
+
+This is equivalent to the following code:
+
+```javascript
+const electron = require('electron')
+const app = electron.app
+const BrowserWindow = electron.BrowserWindow
+let win
+
+app.on('ready', () => {
+  win = new BrowserWindow()
+  win.loadURL('https://github.com')
+})
+```
+
+[gui]: https://en.wikipedia.org/wiki/Graphical_user_interface
+[destructuring-assignment]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment

--- a/test/fixtures/electron/docs/api/system-preferences.md
+++ b/test/fixtures/electron/docs/api/system-preferences.md
@@ -1,0 +1,225 @@
+# systemPreferences
+
+> Get system preferences.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+```javascript
+const {systemPreferences} = require('electron')
+console.log(systemPreferences.isDarkMode())
+```
+
+## Events
+
+The `systemPreferences` object emits the following events:
+
+### Event: 'accent-color-changed' _Windows_
+
+Returns:
+
+* `event` Event
+* `newColor` String - The new RGBA color the user assigned to be there system
+  accent color.
+
+### Event: 'color-changed' _Windows_
+
+Returns:
+
+* `event` Event
+
+### Event: 'inverted-color-scheme-changed' _Windows_
+
+Returns:
+
+* `event` Event
+* `invertedColorScheme` Boolean - `true` if an inverted color scheme, such as
+  a high contrast theme, is being used, `false` otherwise.
+
+## Methods
+
+### `systemPreferences.isDarkMode()` _macOS_
+
+Returns `Boolean` - Whether the system is in Dark Mode.
+
+### `systemPreferences.isSwipeTrackingFromScrollEventsEnabled()` _macOS_
+
+Returns `Boolean` - Whether the Swipe between pages setting is on.
+
+### `systemPreferences.postNotification(event, userInfo)` _macOS_
+
+* `event` String
+* `userInfo` Object
+
+Posts `event` as native notifications of macOS. The `userInfo` is an Object
+that contains the user information dictionary sent along with the notification.
+
+### `systemPreferences.postLocalNotification(event, userInfo)` _macOS_
+
+* `event` String
+* `userInfo` Object
+
+Posts `event` as native notifications of macOS. The `userInfo` is an Object
+that contains the user information dictionary sent along with the notification.
+
+### `systemPreferences.subscribeNotification(event, callback)` _macOS_
+
+* `event` String
+* `callback` Function
+  * `event` String
+  * `userInfo` Object
+
+Subscribes to native notifications of macOS, `callback` will be called with
+`callback(event, userInfo)` when the corresponding `event` happens. The
+`userInfo` is an Object that contains the user information dictionary sent
+along with the notification.
+
+The `id` of the subscriber is returned, which can be used to unsubscribe the
+`event`.
+
+Under the hood this API subscribes to `NSDistributedNotificationCenter`,
+example values of `event` are:
+
+* `AppleInterfaceThemeChangedNotification`
+* `AppleAquaColorVariantChanged`
+* `AppleColorPreferencesChangedNotification`
+* `AppleShowScrollBarsSettingChanged`
+
+### `systemPreferences.unsubscribeNotification(id)` _macOS_
+
+* `id` Integer
+
+Removes the subscriber with `id`.
+
+### `systemPreferences.subscribeLocalNotification(event, callback)` _macOS_
+
+* `event` String
+* `callback` Function
+  * `event` String
+  * `userInfo` Object
+
+Same as `subscribeNotification`, but uses `NSNotificationCenter` for local defaults.
+This is necessary for events such as `NSUserDefaultsDidChangeNotification`
+
+### `systemPreferences.unsubscribeLocalNotification(id)` _macOS_
+
+* `id` Integer
+
+Same as `unsubscribeNotification`, but removes the subscriber from `NSNotificationCenter`.
+
+### `systemPreferences.getUserDefault(key, type)` _macOS_
+
+* `key` String
+* `type` String - Can be `string`, `boolean`, `integer`, `float`, `double`,
+  `url`, `array`, `dictionary`
+
+Get the value of `key` in system preferences.
+
+This API reads from `NSUserDefaults` on macOS, some popular `key` and `type`s
+are:
+
+* `AppleInterfaceStyle: string`
+* `AppleAquaColorVariant: integer`
+* `AppleHighlightColor: string`
+* `AppleShowScrollBars: string`
+* `NSNavRecentPlaces: array`
+* `NSPreferredWebServices: dictionary`
+* `NSUserDictionaryReplacementItems: array`
+
+### `systemPreferences.isAeroGlassEnabled()` _Windows_
+
+This method returns `true` if [DWM composition][dwm-composition] (Aero Glass) is
+enabled, and `false` otherwise.
+
+An example of using it to determine if you should create a transparent window or
+not (transparent windows won't work correctly when DWM composition is disabled):
+
+```javascript
+const {BrowserWindow, systemPreferences} = require('electron')
+let browserOptions = {width: 1000, height: 800}
+
+// Make the window transparent only if the platform supports it.
+if (process.platform !== 'win32' || systemPreferences.isAeroGlassEnabled()) {
+  browserOptions.transparent = true
+  browserOptions.frame = false
+}
+
+// Create the window.
+let win = new BrowserWindow(browserOptions)
+
+// Navigate.
+if (browserOptions.transparent) {
+  win.loadURL(`file://${__dirname}/index.html`)
+} else {
+  // No transparency, so we load a fallback that uses basic styles.
+  win.loadURL(`file://${__dirname}/fallback.html`)
+}
+```
+
+[dwm-composition]:https://msdn.microsoft.com/en-us/library/windows/desktop/aa969540.aspx
+
+### `systemPreferences.getAccentColor()` _Windows_
+
+Returns `String` - The users current system wide accent color preference in RGBA
+hexadecimal form.
+
+```js
+const color = systemPreferences.getAccentColor() // `"aabbccdd"`
+const red = color.substr(0, 2) // "aa"
+const green = color.substr(2, 2) // "bb"
+const blue = color.substr(4, 2) // "cc"
+const alpha = color.substr(6, 2) // "dd"
+```
+
+### `systemPreferences.getColor(color)` _Windows_
+
+* `color` String - One of the following values:
+  * `3d-dark-shadow` - Dark shadow for three-dimensional display elements.
+  * `3d-face` - Face color for three-dimensional display elements and for dialog
+    box backgrounds.
+  * `3d-highlight` - Highlight color for three-dimensional display elements.
+  * `3d-light` - Light color for three-dimensional display elements.
+  * `3d-shadow` - Shadow color for three-dimensional display elements.
+  * `active-border` - Active window border.
+  * `active-caption` - Active window title bar. Specifies the left side color in
+    the color gradient of an active window's title bar if the gradient effect is
+    enabled.
+  * `active-caption-gradient` - Right side color in the color gradient of an
+    active window's title bar.
+  * `app-workspace` - Background color of multiple document interface (MDI)
+    applications.
+  * `button-text` - Text on push buttons.
+  * `caption-text` - Text in caption, size box, and scroll bar arrow box.
+  * `desktop` - Desktop background color.
+  * `disabled-text` - Grayed (disabled) text.
+  * `highlight` - Item(s) selected in a control.
+  * `highlight-text` - Text of item(s) selected in a control.
+  * `hotlight` - Color for a hyperlink or hot-tracked item.
+  * `inactive-border` - Inactive window border.
+  * `inactive-caption` - Inactive window caption. Specifies the left side color
+    in the color gradient of an inactive window's title bar if the gradient
+    effect is enabled.
+  * `inactive-caption-gradient` - Right side color in the color gradient of an
+    inactive window's title bar.
+  * `inactive-caption-text` - Color of text in an inactive caption.
+  * `info-background` - Background color for tooltip controls.
+  * `info-text` - Text color for tooltip controls.
+  * `menu` - Menu background.
+  * `menu-highlight` - The color used to highlight menu items when the menu
+    appears as a flat menu.
+  * `menubar` - The background color for the menu bar when menus appear as flat
+    menus.
+  * `menu-text` - Text in menus.
+  * `scrollbar` - Scroll bar gray area.
+  * `window` - Window background.
+  * `window-frame` - Window frame.
+  * `window-text` - Text in windows.
+
+Returns `String` - The system color setting in RGB hexadecimal form (`#ABCDEF`).
+See the [Windows docs][windows-colors] for more details.
+
+### `systemPreferences.isInvertedColorScheme()` _Windows_
+
+Returns `Boolean` - `true` if an inverted color scheme, such as a high contrast
+theme, is active, `false` otherwise.
+
+[windows-colors]:https://msdn.microsoft.com/en-us/library/windows/desktop/ms724371(v=vs.85).aspx

--- a/test/fixtures/electron/docs/api/tray.md
+++ b/test/fixtures/electron/docs/api/tray.md
@@ -57,7 +57,7 @@ rely on the `click` event and always attach a context menu to the tray icon.
 
 ### `new Tray(image)`
 
-* `image` [NativeImage](native-image.md)
+* `image` ([NativeImage](native-image.md) | String)
 
 Creates a new tray icon associated with the `image`.
 

--- a/test/fixtures/electron/docs/api/tray.md
+++ b/test/fixtures/electron/docs/api/tray.md
@@ -1,0 +1,244 @@
+# Tray
+
+> Add icons and context menus to the system's notification area.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+```javascript
+const {app, Menu, Tray} = require('electron')
+
+let tray = null
+app.on('ready', () => {
+  tray = new Tray('/path/to/my/icon')
+  const contextMenu = Menu.buildFromTemplate([
+    {label: 'Item1', type: 'radio'},
+    {label: 'Item2', type: 'radio'},
+    {label: 'Item3', type: 'radio', checked: true},
+    {label: 'Item4', type: 'radio'}
+  ])
+  tray.setToolTip('This is my application.')
+  tray.setContextMenu(contextMenu)
+})
+```
+
+__Platform limitations:__
+
+* On Linux the app indicator will be used if it is supported, otherwise
+  `GtkStatusIcon` will be used instead.
+* On Linux distributions that only have app indicator support, you have to
+  install `libappindicator1` to make the tray icon work.
+* App indicator will only be shown when it has a context menu.
+* When app indicator is used on Linux, the `click` event is ignored.
+* On Linux in order for changes made to individual `MenuItem`s to take effect,
+  you have to call `setContextMenu` again. For example:
+
+```javascript
+const {Menu, Tray} = require('electron')
+const appIcon = new Tray('/path/to/my/icon')
+const contextMenu = Menu.buildFromTemplate([
+  {label: 'Item1', type: 'radio'},
+  {label: 'Item2', type: 'radio'}
+])
+
+// Make a change to the context menu
+contextMenu.items[2].checked = false
+
+// Call this again for Linux because we modified the context menu
+appIcon.setContextMenu(contextMenu)
+```
+* On Windows it is recommended to use `ICO` icons to get best visual effects.
+
+If you want to keep exact same behaviors on all platforms, you should not
+rely on the `click` event and always attach a context menu to the tray icon.
+
+## Class: Tray
+
+`Tray` is an [EventEmitter][event-emitter].
+
+### `new Tray(image)`
+
+* `image` [NativeImage](native-image.md)
+
+Creates a new tray icon associated with the `image`.
+
+### Instance Events
+
+The `Tray` module emits the following events:
+
+#### Event: 'click'
+
+* `event` Event
+  * `altKey` Boolean
+  * `shiftKey` Boolean
+  * `ctrlKey` Boolean
+  * `metaKey` Boolean
+* `bounds` [Rectangle](structures/rectangle.md) - The bounds of tray icon
+
+Emitted when the tray icon is clicked.
+
+#### Event: 'right-click' _macOS_ _Windows_
+
+* `event` Event
+  * `altKey` Boolean
+  * `shiftKey` Boolean
+  * `ctrlKey` Boolean
+  * `metaKey` Boolean
+* `bounds` [Rectangle](structures/rectangle.md) - The bounds of tray icon
+
+Emitted when the tray icon is right clicked.
+
+#### Event: 'double-click' _macOS_ _Windows_
+
+* `event` Event
+  * `altKey` Boolean
+  * `shiftKey` Boolean
+  * `ctrlKey` Boolean
+  * `metaKey` Boolean
+* `bounds` [Rectangle](structures/rectangle.md) - The bounds of tray icon
+
+Emitted when the tray icon is double clicked.
+
+#### Event: 'balloon-show' _Windows_
+
+Emitted when the tray balloon shows.
+
+#### Event: 'balloon-click' _Windows_
+
+Emitted when the tray balloon is clicked.
+
+#### Event: 'balloon-closed' _Windows_
+
+Emitted when the tray balloon is closed because of timeout or user manually
+closes it.
+
+#### Event: 'drop' _macOS_
+
+Emitted when any dragged items are dropped on the tray icon.
+
+#### Event: 'drop-files' _macOS_
+
+* `event` Event
+* `files` String[] - The paths of the dropped files.
+
+Emitted when dragged files are dropped in the tray icon.
+
+#### Event: 'drop-text' _macOS_
+
+* `event` Event
+* `text` String - the dropped text string
+
+Emitted when dragged text is dropped in the tray icon.
+
+#### Event: 'drag-enter' _macOS_
+
+Emitted when a drag operation enters the tray icon.
+
+#### Event: 'drag-leave' _macOS_
+
+Emitted when a drag operation exits the tray icon.
+
+#### Event: 'drag-end' _macOS_
+
+Emitted when a drag operation ends on the tray or ends at another location.
+
+### Instance Methods
+
+The `Tray` class has the following methods:
+
+#### `tray.destroy()`
+
+Destroys the tray icon immediately.
+
+#### `tray.setImage(image)`
+
+* `image` [NativeImage](native-image.md)
+
+Sets the `image` associated with this tray icon.
+
+#### `tray.setPressedImage(image)` _macOS_
+
+* `image` [NativeImage](native-image.md)
+
+Sets the `image` associated with this tray icon when pressed on macOS.
+
+#### `tray.setToolTip(toolTip)`
+
+* `toolTip` String
+
+Sets the hover text for this tray icon.
+
+#### `tray.setTitle(title)` _macOS_
+
+* `title` String
+
+Sets the title displayed aside of the tray icon in the status bar.
+
+#### `tray.setHighlightMode(mode)` _macOS_
+
+* `mode` String - Highlight mode with one of the following values:
+  * `selection` - Highlight the tray icon when it is clicked and also when
+    its context menu is open. This is the default.
+  * `always` - Always highlight the tray icon.
+  * `never` - Never highlight the tray icon.
+
+Sets when the tray's icon background becomes highlighted (in blue).
+
+**Note:** You can use `highlightMode` with a [`BrowserWindow`](browser-window.md)
+by toggling between `'never'` and `'always'` modes when the window visibility
+changes.
+
+```javascript
+const {BrowserWindow, Tray} = require('electron')
+
+const win = new BrowserWindow({width: 800, height: 600})
+const tray = new Tray('/path/to/my/icon')
+
+tray.on('click', () => {
+  win.isVisible() ? win.hide() : win.show()
+})
+win.on('show', () => {
+  tray.setHighlightMode('always')
+})
+win.on('hide', () => {
+  tray.setHighlightMode('never')
+})
+```
+
+#### `tray.displayBalloon(options)` _Windows_
+
+* `options` Object
+  * `icon` [NativeImage](native-image.md)
+  * `title` String
+  * `content` String
+
+Displays a tray balloon.
+
+#### `tray.popUpContextMenu([menu, position])` _macOS_ _Windows_
+
+* `menu` Menu (optional)
+* `position` Object (optional) - The pop up position.
+  * `x` Integer
+  * `y` Integer
+
+Pops up the context menu of the tray icon. When `menu` is passed, the `menu` will
+be shown instead of the tray icon's context menu.
+
+The `position` is only available on Windows, and it is (0, 0) by default.
+
+#### `tray.setContextMenu(menu)`
+
+* `menu` Menu
+
+Sets the context menu for this icon.
+
+#### `tray.getBounds()` _macOS_ _Windows_
+
+Returns [`Rectangle`](structures/rectangle.md)
+
+The `bounds` of this tray icon as `Object`.
+
+#### `tray.isDestroyed()`
+
+Returns `Boolean` - Whether the tray icon is destroyed.
+
+[event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter

--- a/test/fixtures/electron/docs/api/web-contents.md
+++ b/test/fixtures/electron/docs/api/web-contents.md
@@ -952,6 +952,7 @@ Opens the developer tools for the service worker context.
 #### `contents.send(channel[, arg1][, arg2][, ...])`
 
 * `channel` String
+* `...args` any[]
 
 Send an asynchronous message to renderer process via `channel`, you can also
 send arbitrary arguments. Arguments will be serialized in JSON internally and

--- a/test/fixtures/electron/docs/api/web-contents.md
+++ b/test/fixtures/electron/docs/api/web-contents.md
@@ -1,0 +1,1271 @@
+# webContents
+
+> Render and control web pages.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+`webContents` is an
+[EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter).
+It is responsible for rendering and controlling a web page and is a property of
+the [`BrowserWindow`](browser-window.md) object. An example of accessing the
+`webContents` object:
+
+```javascript
+const {BrowserWindow} = require('electron')
+
+let win = new BrowserWindow({width: 800, height: 1500})
+win.loadURL('http://github.com')
+
+let contents = win.webContents
+console.log(contents)
+```
+
+## Methods
+
+These methods can be accessed from the `webContents` module:
+
+```javascript
+const {webContents} = require('electron')
+console.log(webContents)
+```
+
+### `webContents.getAllWebContents()`
+
+Returns `WebContents[]` - An array of all `WebContents` instances. This will contain web contents
+for all windows, webviews, opened devtools, and devtools extension background pages.
+
+### `webContents.getFocusedWebContents()`
+
+Returns `WebContents` - The web contents that is focused in this application, otherwise
+returns `null`.
+
+### `webContents.fromId(id)`
+
+* `id` Integer
+
+Returns `WebContents` - A WebContents instance with the given ID.
+
+## Class: WebContents
+
+> Render and control the contents of a BrowserWindow instance.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+### Instance Events
+
+#### Event: 'did-finish-load'
+
+Emitted when the navigation is done, i.e. the spinner of the tab has stopped
+spinning, and the `onload` event was dispatched.
+
+#### Event: 'did-fail-load'
+
+Returns:
+
+* `event` Event
+* `errorCode` Integer
+* `errorDescription` String
+* `validatedURL` String
+* `isMainFrame` Boolean
+
+This event is like `did-finish-load` but emitted when the load failed or was
+cancelled, e.g. `window.stop()` is invoked.
+The full list of error codes and their meaning is available [here](https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h).
+Note that redirect responses will emit `errorCode` -3; you may want to ignore
+that error explicitly.
+
+#### Event: 'did-frame-finish-load'
+
+Returns:
+
+* `event` Event
+* `isMainFrame` Boolean
+
+Emitted when a frame has done navigation.
+
+#### Event: 'did-start-loading'
+
+Corresponds to the points in time when the spinner of the tab started spinning.
+
+#### Event: 'did-stop-loading'
+
+Corresponds to the points in time when the spinner of the tab stopped spinning.
+
+#### Event: 'did-get-response-details'
+
+Returns:
+
+* `event` Event
+* `status` Boolean
+* `newURL` String
+* `originalURL` String
+* `httpResponseCode` Integer
+* `requestMethod` String
+* `referrer` String
+* `headers` Object
+* `resourceType` String
+
+Emitted when details regarding a requested resource are available.
+`status` indicates the socket connection to download the resource.
+
+#### Event: 'did-get-redirect-request'
+
+Returns:
+
+* `event` Event
+* `oldURL` String
+* `newURL` String
+* `isMainFrame` Boolean
+* `httpResponseCode` Integer
+* `requestMethod` String
+* `referrer` String
+* `headers` Object
+
+Emitted when a redirect is received while requesting a resource.
+
+#### Event: 'dom-ready'
+
+Returns:
+
+* `event` Event
+
+Emitted when the document in the given frame is loaded.
+
+#### Event: 'page-favicon-updated'
+
+Returns:
+
+* `event` Event
+* `favicons` String[] - Array of URLs
+
+Emitted when page receives favicon urls.
+
+#### Event: 'new-window'
+
+Returns:
+
+* `event` Event
+* `url` String
+* `frameName` String
+* `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,
+  `new-window`, `save-to-disk` and `other`.
+* `options` Object - The options which will be used for creating the new
+  `BrowserWindow`.
+* `additionalFeatures` String[] - The non-standard features (features not handled
+  by Chromium or Electron) given to `window.open()`.
+
+Emitted when the page requests to open a new window for a `url`. It could be
+requested by `window.open` or an external link like `<a target='_blank'>`.
+
+By default a new `BrowserWindow` will be created for the `url`.
+
+Calling `event.preventDefault()` will prevent creating new windows. In such case, the
+`event.newGuest` may be set with a reference to a `BrowserWindow` instance to make it
+used by the Electron's runtime.
+
+#### Event: 'will-navigate'
+
+Returns:
+
+* `event` Event
+* `url` String
+
+Emitted when a user or the page wants to start navigation. It can happen when
+the `window.location` object is changed or a user clicks a link in the page.
+
+This event will not emit when the navigation is started programmatically with
+APIs like `webContents.loadURL` and `webContents.back`.
+
+It is also not emitted for in-page navigations, such as clicking anchor links
+or updating the `window.location.hash`. Use `did-navigate-in-page` event for
+this purpose.
+
+Calling `event.preventDefault()` will prevent the navigation.
+
+#### Event: 'did-navigate'
+
+Returns:
+
+* `event` Event
+* `url` String
+
+Emitted when a navigation is done.
+
+This event is not emitted for in-page navigations, such as clicking anchor links
+or updating the `window.location.hash`. Use `did-navigate-in-page` event for
+this purpose.
+
+#### Event: 'did-navigate-in-page'
+
+Returns:
+
+* `event` Event
+* `url` String
+* `isMainFrame` Boolean
+
+Emitted when an in-page navigation happened.
+
+When in-page navigation happens, the page URL changes but does not cause
+navigation outside of the page. Examples of this occurring are when anchor links
+are clicked or when the DOM `hashchange` event is triggered.
+
+#### Event: 'crashed'
+
+Returns:
+
+* `event` Event
+* `killed` Boolean
+
+Emitted when the renderer process crashes or is killed.
+
+#### Event: 'plugin-crashed'
+
+Returns:
+
+* `event` Event
+* `name` String
+* `version` String
+
+Emitted when a plugin process has crashed.
+
+#### Event: 'destroyed'
+
+Emitted when `webContents` is destroyed.
+
+#### Event: 'devtools-opened'
+
+Emitted when DevTools is opened.
+
+#### Event: 'devtools-closed'
+
+Emitted when DevTools is closed.
+
+#### Event: 'devtools-focused'
+
+Emitted when DevTools is focused / opened.
+
+#### Event: 'certificate-error'
+
+Returns:
+
+* `event` Event
+* `url` URL
+* `error` String - The error code
+* `certificate` [Certificate](structures/certificate.md)
+* `callback` Function
+  * `isTrusted` Boolean - Indicates whether the certificate can be considered trusted
+
+Emitted when failed to verify the `certificate` for `url`.
+
+The usage is the same with [the `certificate-error` event of
+`app`](app.md#event-certificate-error).
+
+#### Event: 'select-client-certificate'
+
+Returns:
+
+* `event` Event
+* `url` URL
+* `certificateList` [Certificate[]](structures/certificate.md)
+* `callback` Function
+  * `certificate` [Certificate](structures/certificate.md) - Must be a certificate from the given list
+
+Emitted when a client certificate is requested.
+
+The usage is the same with [the `select-client-certificate` event of
+`app`](app.md#event-select-client-certificate).
+
+#### Event: 'login'
+
+Returns:
+
+* `event` Event
+* `request` Object
+  * `method` String
+  * `url` URL
+  * `referrer` URL
+* `authInfo` Object
+  * `isProxy` Boolean
+  * `scheme` String
+  * `host` String
+  * `port` Integer
+  * `realm` String
+* `callback` Function
+  * `username` String
+  * `password` String
+
+Emitted when `webContents` wants to do basic auth.
+
+The usage is the same with [the `login` event of `app`](app.md#event-login).
+
+#### Event: 'found-in-page'
+
+Returns:
+
+* `event` Event
+* `result` Object
+  * `requestId` Integer
+  * `activeMatchOrdinal` Integer - Position of the active match.
+  * `matches` Integer - Number of Matches.
+  * `selectionArea` Object - Coordinates of first match region.
+
+Emitted when a result is available for
+[`webContents.findInPage`] request.
+
+#### Event: 'media-started-playing'
+
+Emitted when media starts playing.
+
+#### Event: 'media-paused'
+
+Emitted when media is paused or done playing.
+
+#### Event: 'did-change-theme-color'
+
+Emitted when a page's theme color changes. This is usually due to encountering
+a meta tag:
+
+```html
+<meta name='theme-color' content='#ff0000'>
+```
+
+#### Event: 'update-target-url'
+
+Returns:
+
+* `event` Event
+* `url` String
+
+Emitted when mouse moves over a link or the keyboard moves the focus to a link.
+
+#### Event: 'cursor-changed'
+
+Returns:
+
+* `event` Event
+* `type` String
+* `image` NativeImage (optional)
+* `scale` Float (optional) - scaling factor for the custom cursor
+* `size` Object (optional) - the size of the `image`
+  * `width` Integer
+  * `height` Integer
+* `hotspot` Object (optional) - coordinates of the custom cursor's hotspot
+  * `x` Integer - x coordinate
+  * `y` Integer - y coordinate
+
+Emitted when the cursor's type changes. The `type` parameter can be `default`,
+`crosshair`, `pointer`, `text`, `wait`, `help`, `e-resize`, `n-resize`,
+`ne-resize`, `nw-resize`, `s-resize`, `se-resize`, `sw-resize`, `w-resize`,
+`ns-resize`, `ew-resize`, `nesw-resize`, `nwse-resize`, `col-resize`,
+`row-resize`, `m-panning`, `e-panning`, `n-panning`, `ne-panning`, `nw-panning`,
+`s-panning`, `se-panning`, `sw-panning`, `w-panning`, `move`, `vertical-text`,
+`cell`, `context-menu`, `alias`, `progress`, `nodrop`, `copy`, `none`,
+`not-allowed`, `zoom-in`, `zoom-out`, `grab`, `grabbing`, `custom`.
+
+If the `type` parameter is `custom`, the `image` parameter will hold the custom
+cursor image in a `NativeImage`, and `scale`, `size` and `hotspot` will hold
+additional information about the custom cursor.
+
+#### Event: 'context-menu'
+
+Returns:
+
+* `event` Event
+* `params` Object
+  * `x` Integer - x coordinate
+  * `y` Integer - y coordinate
+  * `linkURL` String - URL of the link that encloses the node the context menu
+    was invoked on.
+  * `linkText` String - Text associated with the link. May be an empty
+    string if the contents of the link are an image.
+  * `pageURL` String - URL of the top level page that the context menu was
+    invoked on.
+  * `frameURL` String - URL of the subframe that the context menu was invoked
+    on.
+  * `srcURL` String - Source URL for the element that the context menu
+    was invoked on. Elements with source URLs are images, audio and video.
+  * `mediaType` String - Type of the node the context menu was invoked on. Can
+    be `none`, `image`, `audio`, `video`, `canvas`, `file` or `plugin`.
+  * `hasImageContents` Boolean - Whether the context menu was invoked on an image
+    which has non-empty contents.
+  * `isEditable` Boolean - Whether the context is editable.
+  * `selectionText` String - Text of the selection that the context menu was
+    invoked on.
+  * `titleText` String - Title or alt text of the selection that the context
+    was invoked on.
+  * `misspelledWord` String - The misspelled word under the cursor, if any.
+  * `frameCharset` String - The character encoding of the frame on which the
+    menu was invoked.
+  * `inputFieldType` String - If the context menu was invoked on an input
+    field, the type of that field. Possible values are `none`, `plainText`,
+    `password`, `other`.
+  * `menuSourceType` String - Input source that invoked the context menu.
+    Can be `none`, `mouse`, `keyboard`, `touch`, `touchMenu`.
+  * `mediaFlags` Object - The flags for the media element the context menu was
+    invoked on.
+    * `inError` Boolean - Whether the media element has crashed.
+    * `isPaused` Boolean - Whether the media element is paused.
+    * `isMuted` Boolean - Whether the media element is muted.
+    * `hasAudio` Boolean - Whether the media element has audio.
+    * `isLooping` Boolean - Whether the media element is looping.
+    * `isControlsVisible` Boolean - Whether the media element's controls are
+      visible.
+    * `canToggleControls` Boolean - Whether the media element's controls are
+      toggleable.
+    * `canRotate` Boolean - Whether the media element can be rotated.
+  * `editFlags` Object - These flags indicate whether the renderer believes it
+    is able to perform the corresponding action.
+    * `canUndo` Boolean - Whether the renderer believes it can undo.
+    * `canRedo` Boolean - Whether the renderer believes it can redo.
+    * `canCut` Boolean - Whether the renderer believes it can cut.
+    * `canCopy` Boolean - Whether the renderer believes it can copy
+    * `canPaste` Boolean - Whether the renderer believes it can paste.
+    * `canDelete` Boolean - Whether the renderer believes it can delete.
+    * `canSelectAll` Boolean - Whether the renderer believes it can select all.
+
+Emitted when there is a new context menu that needs to be handled.
+
+#### Event: 'select-bluetooth-device'
+
+Returns:
+
+* `event` Event
+* `devices` [BluetoothDevice[]](structures/bluetooth-device.md)
+* `callback` Function
+  * `deviceId` String
+
+Emitted when bluetooth device needs to be selected on call to
+`navigator.bluetooth.requestDevice`. To use `navigator.bluetooth` api
+`webBluetooth` should be enabled.  If `event.preventDefault` is not called,
+first available device will be selected. `callback` should be called with
+`deviceId` to be selected, passing empty string to `callback` will
+cancel the request.
+
+```javascript
+const {app, webContents} = require('electron')
+app.commandLine.appendSwitch('enable-web-bluetooth')
+
+app.on('ready', () => {
+  webContents.on('select-bluetooth-device', (event, deviceList, callback) => {
+    event.preventDefault()
+    let result = deviceList.find((device) => {
+      return device.deviceName === 'test'
+    })
+    if (!result) {
+      callback('')
+    } else {
+      callback(result.deviceId)
+    }
+  })
+})
+```
+
+#### Event: 'paint'
+
+Returns:
+
+* `event` Event
+* `dirtyRect` [Rectangle](structures/rectangle.md)
+* `image` [NativeImage](native-image.md) - The image data of the whole frame.
+
+Emitted when a new frame is generated. Only the dirty area is passed in the
+buffer.
+
+```javascript
+const {BrowserWindow} = require('electron')
+
+let win = new BrowserWindow({webPreferences: {offscreen: true}})
+win.webContents.on('paint', (event, dirty, image) => {
+  // updateBitmap(dirty, image.getBitmap())
+})
+win.loadURL('http://github.com')
+```
+
+### Instance Methods
+
+#### `contents.loadURL(url[, options])`
+
+* `url` URL
+* `options` Object (optional)
+  * `httpReferrer` String - A HTTP Referrer url.
+  * `userAgent` String - A user agent originating the request.
+  * `extraHeaders` String - Extra headers separated by "\n"
+
+Loads the `url` in the window. The `url` must contain the protocol prefix,
+e.g. the `http://` or `file://`. If the load should bypass http cache then
+use the `pragma` header to achieve it.
+
+```javascript
+const {webContents} = require('electron')
+const options = {extraHeaders: 'pragma: no-cache\n'}
+webContents.loadURL('https://github.com', options)
+```
+
+#### `contents.downloadURL(url)`
+
+* `url` String
+
+Initiates a download of the resource at `url` without navigating. The
+`will-download` event of `session` will be triggered.
+
+#### `contents.getURL()`
+
+Returns `String` - The URL of the current web page.
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow({width: 800, height: 600})
+win.loadURL('http://github.com')
+
+let currentURL = win.webContents.getURL()
+console.log(currentURL)
+```
+
+#### `contents.getTitle()`
+
+Returns `String` - The title of the current web page.
+
+#### `contents.isDestroyed()`
+
+Returns `Boolean` - Whether the web page is destroyed.
+
+#### `contents.isFocused()`
+
+Returns `Boolean` - Whether the web page is focused.
+
+#### `contents.isLoading()`
+
+Returns `Boolean` - Whether web page is still loading resources.
+
+#### `contents.isLoadingMainFrame()`
+
+Returns `Boolean` - Whether the main frame (and not just iframes or frames within it) is
+still loading.
+
+#### `contents.isWaitingForResponse()`
+
+Returns `Boolean` - Whether the web page is waiting for a first-response from the main
+resource of the page.
+
+#### `contents.stop()`
+
+Stops any pending navigation.
+
+#### `contents.reload()`
+
+Reloads the current web page.
+
+#### `contents.reloadIgnoringCache()`
+
+Reloads current page and ignores cache.
+
+#### `contents.canGoBack()`
+
+Returns `Boolean` - Whether the browser can go back to previous web page.
+
+#### `contents.canGoForward()`
+
+Returns `Boolean` - Whether the browser can go forward to next web page.
+
+#### `contents.canGoToOffset(offset)`
+
+* `offset` Integer
+
+Returns `Boolean` - Whether the web page can go to `offset`.
+
+#### `contents.clearHistory()`
+
+Clears the navigation history.
+
+#### `contents.goBack()`
+
+Makes the browser go back a web page.
+
+#### `contents.goForward()`
+
+Makes the browser go forward a web page.
+
+#### `contents.goToIndex(index)`
+
+* `index` Integer
+
+Navigates browser to the specified absolute web page index.
+
+#### `contents.goToOffset(offset)`
+
+* `offset` Integer
+
+Navigates to the specified offset from the "current entry".
+
+#### `contents.isCrashed()`
+
+Returns `Boolean` - Whether the renderer process has crashed.
+
+#### `contents.setUserAgent(userAgent)`
+
+* `userAgent` String
+
+Overrides the user agent for this web page.
+
+#### `contents.getUserAgent()`
+
+Returns `String` - The user agent for this web page.
+
+#### `contents.insertCSS(css)`
+
+* `css` String
+
+Injects CSS into the current web page.
+
+#### `contents.executeJavaScript(code[, userGesture, callback])`
+
+* `code` String
+* `userGesture` Boolean (optional)
+* `callback` Function (optional) - Called after script has been executed.
+  * `result` Any
+
+Returns `Promise` - A promise that resolves with the result of the executed code
+or is rejected if the result of the code is a rejected promise.
+
+Evaluates `code` in page.
+
+In the browser window some HTML APIs like `requestFullScreen` can only be
+invoked by a gesture from the user. Setting `userGesture` to `true` will remove
+this limitation.
+
+If the result of the executed code is a promise the callback result will be the
+resolved value of the promise.  We recommend that you use the returned Promise
+to handle code that results in a Promise.
+
+```js
+contents.executeJavaScript('fetch("https://jsonplaceholder.typicode.com/users/1").then(resp => resp.json())', true)
+  .then((result) => {
+    console.log(result) // Will be the JSON object from the fetch call
+  })
+```
+
+#### `contents.setAudioMuted(muted)`
+
+* `muted` Boolean
+
+Mute the audio on the current web page.
+
+#### `contents.isAudioMuted()`
+
+Returns `Boolean` - Whether this page has been muted.
+
+#### `contents.setZoomFactor(factor)`
+
+* `factor` Number - Zoom factor.
+
+Changes the zoom factor to the specified factor. Zoom factor is
+zoom percent divided by 100, so 300% = 3.0.
+
+#### `contents.getZoomFactor(callback)`
+
+* `callback` Function
+  * `zoomFactor` Number
+
+Sends a request to get current zoom factor, the `callback` will be called with
+`callback(zoomFactor)`.
+
+#### `contents.setZoomLevel(level)`
+
+* `level` Number - Zoom level
+
+Changes the zoom level to the specified level. The original size is 0 and each
+increment above or below represents zooming 20% larger or smaller to default
+limits of 300% and 50% of original size, respectively.
+
+#### `contents.getZoomLevel(callback)`
+
+* `callback` Function
+  * `zoomLevel` Number
+
+Sends a request to get current zoom level, the `callback` will be called with
+`callback(zoomLevel)`.
+
+#### `contents.setZoomLevelLimits(minimumLevel, maximumLevel)`
+
+* `minimumLevel` Number
+* `maximumLevel` Number
+
+Sets the maximum and minimum zoom level.
+
+#### `contents.undo()`
+
+Executes the editing command `undo` in web page.
+
+#### `contents.redo()`
+
+Executes the editing command `redo` in web page.
+
+#### `contents.cut()`
+
+Executes the editing command `cut` in web page.
+
+#### `contents.copy()`
+
+Executes the editing command `copy` in web page.
+
+#### `contents.copyImageAt(x, y)`
+
+* `x` Integer
+* `y` Integer
+
+Copy the image at the given position to the clipboard.
+
+#### `contents.paste()`
+
+Executes the editing command `paste` in web page.
+
+#### `contents.pasteAndMatchStyle()`
+
+Executes the editing command `pasteAndMatchStyle` in web page.
+
+#### `contents.delete()`
+
+Executes the editing command `delete` in web page.
+
+#### `contents.selectAll()`
+
+Executes the editing command `selectAll` in web page.
+
+#### `contents.unselect()`
+
+Executes the editing command `unselect` in web page.
+
+#### `contents.replace(text)`
+
+* `text` String
+
+Executes the editing command `replace` in web page.
+
+#### `contents.replaceMisspelling(text)`
+
+* `text` String
+
+Executes the editing command `replaceMisspelling` in web page.
+
+#### `contents.insertText(text)`
+
+* `text` String
+
+Inserts `text` to the focused element.
+
+#### `contents.findInPage(text[, options])`
+
+* `text` String - Content to be searched, must not be empty.
+* `options` Object (optional)
+  * `forward` Boolean - Whether to search forward or backward, defaults to `true`.
+  * `findNext` Boolean - Whether the operation is first request or a follow up,
+    defaults to `false`.
+  * `matchCase` Boolean - Whether search should be case-sensitive,
+    defaults to `false`.
+  * `wordStart` Boolean - Whether to look only at the start of words.
+    defaults to `false`.
+  * `medialCapitalAsWordStart` Boolean - When combined with `wordStart`,
+    accepts a match in the middle of a word if the match begins with an
+    uppercase letter followed by a lowercase or non-letter.
+    Accepts several other intra-word matches, defaults to `false`.
+
+Starts a request to find all matches for the `text` in the web page and returns
+an `Integer` representing the request id used for the request. The result of
+the request can be obtained by subscribing to
+[`found-in-page`](web-contents.md#event-found-in-page) event.
+
+#### `contents.stopFindInPage(action)`
+
+* `action` String - Specifies the action to take place when ending
+  [`webContents.findInPage`] request.
+  * `clearSelection` - Clear the selection.
+  * `keepSelection` - Translate the selection into a normal selection.
+  * `activateSelection` - Focus and click the selection node.
+
+Stops any `findInPage` request for the `webContents` with the provided `action`.
+
+```javascript
+const {webContents} = require('electron')
+webContents.on('found-in-page', (event, result) => {
+  if (result.finalUpdate) webContents.stopFindInPage('clearSelection')
+})
+
+const requestId = webContents.findInPage('api')
+console.log(requestId)
+```
+
+#### `contents.capturePage([rect, ]callback)`
+
+* `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured
+* `callback` Function
+  * `image` [NativeImage](native-image.md)
+
+Captures a snapshot of the page within `rect`. Upon completion `callback` will
+be called with `callback(image)`. The `image` is an instance of
+[NativeImage](native-image.md) that stores data of the snapshot. Omitting
+`rect` will capture the whole visible page.
+
+#### `contents.hasServiceWorker(callback)`
+
+* `callback` Function
+  * `hasWorker` Boolean
+
+Checks if any ServiceWorker is registered and returns a boolean as
+response to `callback`.
+
+#### `contents.unregisterServiceWorker(callback)`
+
+* `callback` Function
+  * `success` Boolean
+
+Unregisters any ServiceWorker if present and returns a boolean as
+response to `callback` when the JS promise is fulfilled or false
+when the JS promise is rejected.
+
+#### `contents.print([options])`
+
+* `options` Object (optional)
+  * `silent` Boolean - Don't ask user for print settings. Default is `false`.
+  * `printBackground` Boolean - Also prints the background color and image of
+    the web page. Default is `false`.
+
+Prints window's web page. When `silent` is set to `true`, Electron will pick
+up system's default printer and default settings for printing.
+
+Calling `window.print()` in web page is equivalent to calling
+`webContents.print({silent: false, printBackground: false})`.
+
+Use `page-break-before: always; ` CSS style to force to print to a new page.
+
+#### `contents.printToPDF(options, callback)`
+
+* `options` Object
+  * `marginsType` Integer - Specifies the type of margins to use. Uses 0 for
+    default margin, 1 for no margin, and 2 for minimum margin.
+  * `pageSize` String - Specify page size of the generated PDF. Can be `A3`,
+    `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`
+    and `width` in microns.
+  * `printBackground` Boolean - Whether to print CSS backgrounds.
+  * `printSelectionOnly` Boolean - Whether to print selection only.
+  * `landscape` Boolean - `true` for landscape, `false` for portrait.
+* `callback` Function
+  * `error` Error
+  * `data` Buffer
+
+Prints window's web page as PDF with Chromium's preview printing custom
+settings.
+
+The `callback` will be called with `callback(error, data)` on completion. The
+`data` is a `Buffer` that contains the generated PDF data.
+
+By default, an empty `options` will be regarded as:
+
+```javascript
+{
+  marginsType: 0,
+  printBackground: false,
+  printSelectionOnly: false,
+  landscape: false
+}
+```
+
+Use `page-break-before: always; ` CSS style to force to print to a new page.
+
+An example of `webContents.printToPDF`:
+
+```javascript
+const {BrowserWindow} = require('electron')
+const fs = require('fs')
+
+let win = new BrowserWindow({width: 800, height: 600})
+win.loadURL('http://github.com')
+
+win.webContents.on('did-finish-load', () => {
+  // Use default printing options
+  win.webContents.printToPDF({}, (error, data) => {
+    if (error) throw error
+    fs.writeFile('/tmp/print.pdf', data, (error) => {
+      if (error) throw error
+      console.log('Write PDF successfully.')
+    })
+  })
+})
+```
+
+#### `contents.addWorkSpace(path)`
+
+* `path` String
+
+Adds the specified path to DevTools workspace. Must be used after DevTools
+creation:
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow()
+win.webContents.on('devtools-opened', () => {
+  win.webContents.addWorkSpace(__dirname)
+})
+```
+
+#### `contents.removeWorkSpace(path)`
+
+* `path` String
+
+Removes the specified path from DevTools workspace.
+
+#### `contents.openDevTools([options])`
+
+* `options` Object (optional)
+  * `mode` String - Opens the devtools with specified dock state, can be
+  `right`, `bottom`, `undocked`, `detach`. Defaults to last used dock state.
+  In `undocked` mode it's possible to dock back. In `detach` mode it's not.
+
+Opens the devtools.
+
+#### `contents.closeDevTools()`
+
+Closes the devtools.
+
+#### `contents.isDevToolsOpened()`
+
+Returns `Boolean` - Whether the devtools is opened.
+
+#### `contents.isDevToolsFocused()`
+
+Returns `Boolean` - Whether the devtools view is focused .
+
+#### `contents.toggleDevTools()`
+
+Toggles the developer tools.
+
+#### `contents.inspectElement(x, y)`
+
+* `x` Integer
+* `y` Integer
+
+Starts inspecting element at position (`x`, `y`).
+
+#### `contents.inspectServiceWorker()`
+
+Opens the developer tools for the service worker context.
+
+#### `contents.send(channel[, arg1][, arg2][, ...])`
+
+* `channel` String
+
+Send an asynchronous message to renderer process via `channel`, you can also
+send arbitrary arguments. Arguments will be serialized in JSON internally and
+hence no functions or prototype chain will be included.
+
+The renderer process can handle the message by listening to `channel` with the
+`ipcRenderer` module.
+
+An example of sending messages from the main process to the renderer process:
+
+```javascript
+// In the main process.
+const {app, BrowserWindow} = require('electron')
+let win = null
+
+app.on('ready', () => {
+  win = new BrowserWindow({width: 800, height: 600})
+  win.loadURL(`file://${__dirname}/index.html`)
+  win.webContents.on('did-finish-load', () => {
+    win.webContents.send('ping', 'whoooooooh!')
+  })
+})
+```
+
+```html
+<!-- index.html -->
+<html>
+<body>
+  <script>
+    require('electron').ipcRenderer.on('ping', (event, message) => {
+      console.log(message)  // Prints 'whoooooooh!'
+    })
+  </script>
+</body>
+</html>
+```
+
+#### `contents.enableDeviceEmulation(parameters)`
+
+* `parameters` Object
+  * `screenPosition` String - Specify the screen type to emulate
+      (default: `desktop`)
+    * `desktop` - Desktop screen type
+    * `mobile` - Mobile screen type
+  * `screenSize` Object - Set the emulated screen size (screenPosition == mobile)
+    * `width` Integer - Set the emulated screen width
+    * `height` Integer - Set the emulated screen height
+  * `viewPosition` Object - Position the view on the screen
+      (screenPosition == mobile) (default: `{x: 0, y: 0}`)
+    * `x` Integer - Set the x axis offset from top left corner
+    * `y` Integer - Set the y axis offset from top left corner
+  * `deviceScaleFactor` Integer - Set the device scale factor (if zero defaults to
+      original device scale factor) (default: `0`)
+  * `viewSize` Object - Set the emulated view size (empty means no override)
+    * `width` Integer - Set the emulated view width
+    * `height` Integer - Set the emulated view height
+  * `fitToView` Boolean - Whether emulated view should be scaled down if
+      necessary to fit into available space (default: `false`)
+  * `offset` Object - Offset of the emulated view inside available space (not in
+      fit to view mode) (default: `{x: 0, y: 0}`)
+    * `x` Float - Set the x axis offset from top left corner
+    * `y` Float - Set the y axis offset from top left corner
+  * `scale` Float - Scale of emulated view inside available space (not in fit to
+      view mode) (default: `1`)
+
+Enable device emulation with the given parameters.
+
+#### `contents.disableDeviceEmulation()`
+
+Disable device emulation enabled by `webContents.enableDeviceEmulation`.
+
+#### `contents.sendInputEvent(event)`
+
+* `event` Object
+  * `type` String (**required**) - The type of the event, can be `mouseDown`,
+    `mouseUp`, `mouseEnter`, `mouseLeave`, `contextMenu`, `mouseWheel`,
+    `mouseMove`, `keyDown`, `keyUp`, `char`.
+  * `modifiers` String[] - An array of modifiers of the event, can
+    include `shift`, `control`, `alt`, `meta`, `isKeypad`, `isAutoRepeat`,
+    `leftButtonDown`, `middleButtonDown`, `rightButtonDown`, `capsLock`,
+    `numLock`, `left`, `right`.
+
+Sends an input `event` to the page.
+
+For keyboard events, the `event` object also have following properties:
+
+* `keyCode` String (**required**) - The character that will be sent
+  as the keyboard event. Should only use the valid key codes in
+  [Accelerator](accelerator.md).
+
+For mouse events, the `event` object also have following properties:
+
+* `x` Integer (**required**)
+* `y` Integer (**required**)
+* `button` String - The button pressed, can be `left`, `middle`, `right`
+* `globalX` Integer
+* `globalY` Integer
+* `movementX` Integer
+* `movementY` Integer
+* `clickCount` Integer
+
+For the `mouseWheel` event, the `event` object also have following properties:
+
+* `deltaX` Integer
+* `deltaY` Integer
+* `wheelTicksX` Integer
+* `wheelTicksY` Integer
+* `accelerationRatioX` Integer
+* `accelerationRatioY` Integer
+* `hasPreciseScrollingDeltas` Boolean
+* `canScroll` Boolean
+
+#### `contents.beginFrameSubscription([onlyDirty ,]callback)`
+
+* `onlyDirty` Boolean (optional) - Defaults to `false`
+* `callback` Function
+  * `frameBuffer` Buffer
+  * `dirtyRect` [Rectangle](structures/rectangle.md)
+
+Begin subscribing for presentation events and captured frames, the `callback`
+will be called with `callback(frameBuffer, dirtyRect)` when there is a
+presentation event.
+
+The `frameBuffer` is a `Buffer` that contains raw pixel data. On most machines,
+the pixel data is effectively stored in 32bit BGRA format, but the actual
+representation depends on the endianness of the processor (most modern
+processors are little-endian, on machines with big-endian processors the data
+is in 32bit ARGB format).
+
+The `dirtyRect` is an object with `x, y, width, height` properties that
+describes which part of the page was repainted. If `onlyDirty` is set to
+`true`, `frameBuffer` will only contain the repainted area. `onlyDirty`
+defaults to `false`.
+
+#### `contents.endFrameSubscription()`
+
+End subscribing for frame presentation events.
+
+#### `contents.startDrag(item)`
+
+* `item` Object
+  * `file` String
+  * `icon` [NativeImage](native-image.md)
+
+Sets the `item` as dragging item for current drag-drop operation, `file` is the
+absolute path of the file to be dragged, and `icon` is the image showing under
+the cursor when dragging.
+
+#### `contents.savePage(fullPath, saveType, callback)`
+
+* `fullPath` String - The full file path.
+* `saveType` String - Specify the save type.
+  * `HTMLOnly` - Save only the HTML of the page.
+  * `HTMLComplete` - Save complete-html page.
+  * `MHTML` - Save complete-html page as MHTML.
+* `callback` Function - `(error) => {}`.
+  * `error` Error
+
+Returns true if the process of saving page has been initiated successfully.
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow()
+
+win.loadURL('https://github.com')
+
+win.webContents.on('did-finish-load', () => {
+  win.webContents.savePage('/tmp/test.html', 'HTMLComplete', (error) => {
+    if (!error) console.log('Save page successfully')
+  })
+})
+```
+
+#### `contents.showDefinitionForSelection()` _macOS_
+
+Shows pop-up dictionary that searches the selected word on the page.
+
+#### `contents.isOffscreen()`
+
+Returns `Boolean` - Indicates whether *offscreen rendering* is enabled.
+
+#### `contents.startPainting()`
+
+If *offscreen rendering* is enabled and not painting, start painting.
+
+#### `contents.stopPainting()`
+
+If *offscreen rendering* is enabled and painting, stop painting.
+
+#### `contents.isPainting()`
+
+Returns `Boolean` - If *offscreen rendering* is enabled returns whether it is currently painting.
+
+#### `contents.setFrameRate(fps)`
+
+* `fps` Integer
+
+If *offscreen rendering* is enabled sets the frame rate to the specified number.
+Only values between 1 and 60 are accepted.
+
+#### `contents.getFrameRate()`
+
+Returns `Integer` - If *offscreen rendering* is enabled returns the current frame rate.
+
+#### `contents.invalidate()`
+
+If *offscreen rendering* is enabled invalidates the frame and generates a new
+one through the `'paint'` event.
+
+### Instance Properties
+
+#### `contents.id`
+
+A Integer representing the unique ID of this WebContents.
+
+#### `contents.session`
+
+A Session object ([session](session.md)) used by this webContents.
+
+#### `contents.hostWebContents`
+
+A `WebContents` that might own this `WebContents`.
+
+#### `contents.devToolsWebContents`
+
+A `WebContents` of DevTools for this `WebContents`.
+
+**Note:** Users should never store this object because it may become `null`
+when the DevTools has been closed.
+
+#### `contents.debugger`
+
+A Debugger instance for this webContents.
+
+## Class: Debugger
+
+> An alternate transport for Chrome's remote debugging protocol.
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+Chrome Developer Tools has a [special binding][rdp] available at JavaScript
+runtime that allows interacting with pages and instrumenting them.
+
+```javascript
+const {BrowserWindow} = require('electron')
+let win = new BrowserWindow()
+
+try {
+  win.webContents.debugger.attach('1.1')
+} catch (err) {
+  console.log('Debugger attach failed : ', err)
+}
+
+win.webContents.debugger.on('detach', (event, reason) => {
+  console.log('Debugger detached due to : ', reason)
+})
+
+win.webContents.debugger.on('message', (event, method, params) => {
+  if (method === 'Network.requestWillBeSent') {
+    if (params.request.url === 'https://www.github.com') {
+      win.webContents.debugger.detach()
+    }
+  }
+})
+
+win.webContents.debugger.sendCommand('Network.enable')
+```
+
+### Instance Methods
+
+#### `debugger.attach([protocolVersion])`
+
+* `protocolVersion` String (optional) - Requested debugging protocol version.
+
+Attaches the debugger to the `webContents`.
+
+#### `debugger.isAttached()`
+
+Returns `Boolean` - Whether a debugger is attached to the `webContents`.
+
+#### `debugger.detach()`
+
+Detaches the debugger from the `webContents`.
+
+#### `debugger.sendCommand(method[, commandParams, callback])`
+
+* `method` String - Method name, should be one of the methods defined by the
+   remote debugging protocol.
+* `commandParams` Object (optional) - JSON object with request parameters.
+* `callback` Function (optional) - Response
+  * `error` Object - Error message indicating the failure of the command.
+  * `result` Any - Response defined by the 'returns' attribute of
+     the command description in the remote debugging protocol.
+
+Send given command to the debugging target.
+
+### Instance Events
+
+#### Event: 'detach'
+
+* `event` Event
+* `reason` String - Reason for detaching debugger.
+
+Emitted when debugging session is terminated. This happens either when
+`webContents` is closed or devtools is invoked for the attached `webContents`.
+
+#### Event: 'message'
+
+* `event` Event
+* `method` String - Method name.
+* `params` Object - Event parameters defined by the 'parameters'
+   attribute in the remote debugging protocol.
+
+Emitted whenever debugging target issues instrumentation event.
+
+[rdp]: https://developer.chrome.com/devtools/docs/debugger-protocol
+[`webContents.findInPage`]: web-contents.md#contentsfindinpagetext-options

--- a/test/fixtures/electron/docs/api/web-frame.md
+++ b/test/fixtures/electron/docs/api/web-frame.md
@@ -1,0 +1,174 @@
+# webFrame
+
+> Customize the rendering of the current web page.
+
+Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+
+An example of zooming current page to 200%.
+
+```javascript
+const {webFrame} = require('electron')
+
+webFrame.setZoomFactor(2)
+```
+
+## Methods
+
+The `webFrame` module has the following methods:
+
+### `webFrame.setZoomFactor(factor)`
+
+* `factor` Number - Zoom factor.
+
+Changes the zoom factor to the specified factor. Zoom factor is
+zoom percent divided by 100, so 300% = 3.0.
+
+### `webFrame.getZoomFactor()`
+
+Returns `Number` - The current zoom factor.
+
+### `webFrame.setZoomLevel(level)`
+
+* `level` Number - Zoom level
+
+Changes the zoom level to the specified level. The original size is 0 and each
+increment above or below represents zooming 20% larger or smaller to default
+limits of 300% and 50% of original size, respectively.
+
+### `webFrame.getZoomLevel()`
+
+Returns `Number` - The current zoom level.
+
+### `webFrame.setZoomLevelLimits(minimumLevel, maximumLevel)`
+
+* `minimumLevel` Number
+* `maximumLevel` Number
+
+Sets the maximum and minimum zoom level.
+
+### `webFrame.setSpellCheckProvider(language, autoCorrectWord, provider)`
+
+* `language` String
+* `autoCorrectWord` Boolean
+* `provider` Object
+
+Sets a provider for spell checking in input fields and text areas.
+
+The `provider` must be an object that has a `spellCheck` method that returns
+whether the word passed is correctly spelled.
+
+An example of using [node-spellchecker][spellchecker] as provider:
+
+```javascript
+const {webFrame} = require('electron')
+webFrame.setSpellCheckProvider('en-US', true, {
+  spellCheck (text) {
+    return !(require('spellchecker').isMisspelled(text))
+  }
+})
+```
+
+### `webFrame.registerURLSchemeAsSecure(scheme)`
+
+* `scheme` String
+
+Registers the `scheme` as secure scheme.
+
+Secure schemes do not trigger mixed content warnings. For example, `https` and
+`data` are secure schemes because they cannot be corrupted by active network
+attackers.
+
+### `webFrame.registerURLSchemeAsBypassingCSP(scheme)`
+
+* `scheme` String
+
+Resources will be loaded from this `scheme` regardless of the current page's
+Content Security Policy.
+
+### `webFrame.registerURLSchemeAsPrivileged(scheme[, options])`
+
+* `scheme` String
+* `options` Object (optional)
+  * `secure` Boolean - (optional) Default true.
+  * `bypassCSP` Boolean - (optional) Default true.
+  * `allowServiceWorkers` Boolean - (optional) Default true.
+  * `supportFetchAPI` Boolean - (optional) Default true.
+  * `corsEnabled` Boolean - (optional) Default true.
+
+Registers the `scheme` as secure, bypasses content security policy for resources,
+allows registering ServiceWorker and supports fetch API.
+
+Specify an option with the value of `false` to omit it from the registration.
+An example of registering a privileged scheme, without bypassing Content Security Policy:
+
+```javascript
+const {webFrame} = require('electron')
+webFrame.registerURLSchemeAsPrivileged('foo', { bypassCSP: false })
+```
+
+### `webFrame.insertText(text)`
+
+* `text` String
+
+Inserts `text` to the focused element.
+
+### `webFrame.executeJavaScript(code[, userGesture])`
+
+* `code` String
+* `userGesture` Boolean (optional) - Default is `false`.
+
+Evaluates `code` in page.
+
+In the browser window some HTML APIs like `requestFullScreen` can only be
+invoked by a gesture from the user. Setting `userGesture` to `true` will remove
+this limitation.
+
+### `webFrame.getResourceUsage()`
+
+Returns `Object`:
+
+* `images` [MemoryUsageDetails](structures/memory-usage-details.md)
+* `cssStyleSheets` [MemoryUsageDetails](structures/memory-usage-details.md)
+* `xslStyleSheets` [MemoryUsageDetails](structures/memory-usage-details.md)
+* `fonts` [MemoryUsageDetails](structures/memory-usage-details.md)
+* `other` [MemoryUsageDetails](structures/memory-usage-details.md)
+
+Returns an object describing usage information of Blink's internal memory
+caches.
+
+```javascript
+const {webFrame} = require('electron')
+console.log(webFrame.getResourceUsage())
+```
+
+This will generate:
+
+```javascript
+{
+  images: {
+    count: 22,
+    size: 2549,
+    liveSize: 2542,
+    decodedSize: 478,
+    purgedSize: 0,
+    purgeableSize: 0
+  },
+  cssStyleSheets: { /* same with "images" */ },
+  xslStyleSheets: { /* same with "images" */ },
+  fonts: { /* same with "images" */ },
+  other: { /* same with "images" */ }
+}
+```
+
+### `webFrame.clearCache()`
+
+Attempts to free memory that is no longer being used (like images from a
+previous navigation).
+
+Note that blindly calling this method probably makes Electron slower since it
+will have to refill these emptied caches, you should only call it if an event
+in your app has occurred that makes you think your page is actually using less
+memory (i.e. you have navigated from a super heavy page to a mostly empty one,
+and intend to stay there).
+
+[spellchecker]: https://github.com/atom/node-spellchecker

--- a/test/fixtures/electron/docs/api/web-view-tag.md
+++ b/test/fixtures/electron/docs/api/web-view-tag.md
@@ -1,0 +1,870 @@
+# `<webview>` Tag
+
+> Display external web content in an isolated frame and process.
+
+Use the `webview` tag to embed 'guest' content (such as web pages) in your
+Electron app. The guest content is contained within the `webview` container.
+An embedded page within your app controls how the guest content is laid out and
+rendered.
+
+Unlike an `iframe`, the `webview` runs in a separate process than your
+app. It doesn't have the same permissions as your web page and all interactions
+between your app and embedded content will be asynchronous. This keeps your app
+safe from the embedded content.
+
+For security purposes, `webview` can only be used in `BrowserWindow`s that have
+`nodeIntegration` enabled.
+
+## Example
+
+To embed a web page in your app, add the `webview` tag to your app's embedder
+page (this is the app page that will display the guest content). In its simplest
+form, the `webview` tag includes the `src` of the web page and css styles that
+control the appearance of the `webview` container:
+
+```html
+<webview id="foo" src="https://www.github.com/" style="display:inline-flex; width:640px; height:480px"></webview>
+```
+
+If you want to control the guest content in any way, you can write JavaScript
+that listens for `webview` events and responds to those events using the
+`webview` methods. Here's sample code with two event listeners: one that listens
+for the web page to start loading, the other for the web page to stop loading,
+and displays a "loading..." message during the load time:
+
+```html
+<script>
+  onload = () => {
+    const webview = document.getElementById('foo')
+    const indicator = document.querySelector('.indicator')
+
+    const loadstart = () => {
+      indicator.innerText = 'loading...'
+    }
+
+    const loadstop = () => {
+      indicator.innerText = ''
+    }
+
+    webview.addEventListener('did-start-loading', loadstart)
+    webview.addEventListener('did-stop-loading', loadstop)
+  }
+</script>
+```
+
+## CSS Styling Notes
+
+Please note that the `webview` tag's style uses `display:flex;` internally to
+ensure the child `object` element fills the full height and width of its `webview`
+container when used with traditional and flexbox layouts (since v0.36.11). Please
+do not overwrite the default `display:flex;` CSS property, unless specifying
+`display:inline-flex;` for inline layout.
+
+`webview` has issues being hidden using the `hidden` attribute or using `display: none;`.
+It can cause unusual rendering behaviour within its child `browserplugin` object
+and the web page is reloaded, when the `webview` is un-hidden, as opposed to just
+becoming visible again. The recommended approach is to hide the `webview` using
+CSS by zeroing the `width` & `height` and allowing the element to shrink to the 0px
+dimensions via `flex`.
+
+```html
+<style>
+  webview {
+    display:inline-flex;
+    width:640px;
+    height:480px;
+  }
+  webview.hide {
+    flex: 0 1;
+    width: 0px;
+    height: 0px;
+  }
+</style>
+```
+
+## Tag Attributes
+
+The `webview` tag has the following attributes:
+
+### `src`
+
+```html
+<webview src="https://www.github.com/"></webview>
+```
+
+Returns the visible URL. Writing to this attribute initiates top-level
+navigation.
+
+Assigning `src` its own value will reload the current page.
+
+The `src` attribute can also accept data URLs, such as
+`data:text/plain,Hello, world!`.
+
+### `autosize`
+
+```html
+<webview src="https://www.github.com/" autosize="on" minwidth="576" minheight="432"></webview>
+```
+
+If "on", the `webview` container will automatically resize within the
+bounds specified by the attributes `minwidth`, `minheight`, `maxwidth`, and
+`maxheight`. These constraints do not impact the `webview` unless `autosize` is
+enabled. When `autosize` is enabled, the `webview` container size cannot be less
+than the minimum values or greater than the maximum.
+
+### `nodeintegration`
+
+```html
+<webview src="http://www.google.com/" nodeintegration></webview>
+```
+
+If "on", the guest page in `webview` will have node integration and can use node
+APIs like `require` and `process` to access low level system resources.
+
+### `plugins`
+
+```html
+<webview src="https://www.github.com/" plugins></webview>
+```
+
+If "on", the guest page in `webview` will be able to use browser plugins.
+
+### `preload`
+
+```html
+<webview src="https://www.github.com/" preload="./test.js"></webview>
+```
+
+Specifies a script that will be loaded before other scripts run in the guest
+page. The protocol of script's URL must be either `file:` or `asar:`, because it
+will be loaded by `require` in guest page under the hood.
+
+When the guest page doesn't have node integration this script will still have
+access to all Node APIs, but global objects injected by Node will be deleted
+after this script has finished executing.
+
+### `httpreferrer`
+
+```html
+<webview src="https://www.github.com/" httpreferrer="http://cheng.guru"></webview>
+```
+
+Sets the referrer URL for the guest page.
+
+### `useragent`
+
+```html
+<webview src="https://www.github.com/" useragent="Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko"></webview>
+```
+
+Sets the user agent for the guest page before the page is navigated to. Once the
+page is loaded, use the `setUserAgent` method to change the user agent.
+
+### `disablewebsecurity`
+
+```html
+<webview src="https://www.github.com/" disablewebsecurity></webview>
+```
+
+If "on", the guest page will have web security disabled.
+
+### `partition`
+
+```html
+<webview src="https://github.com" partition="persist:github"></webview>
+<webview src="http://electron.atom.io" partition="electron"></webview>
+```
+
+Sets the session used by the page. If `partition` starts with `persist:`, the
+page will use a persistent session available to all pages in the app with the
+same `partition`. if there is no `persist:` prefix, the page will use an
+in-memory session. By assigning the same `partition`, multiple pages can share
+the same session. If the `partition` is unset then default session of the app
+will be used.
+
+This value can only be modified before the first navigation, since the session
+of an active renderer process cannot change. Subsequent attempts to modify the
+value will fail with a DOM exception.
+
+### `allowpopups`
+
+```html
+<webview src="https://www.github.com/" allowpopups></webview>
+```
+
+If "on", the guest page will be allowed to open new windows.
+
+### `webpreferences`
+
+```html
+<webview src="https://github.com" webpreferences="allowDisplayingInsecureContent, javascript=no"></webview>
+```
+
+A list of strings which specifies the web preferences to be set on the webview, separated by `,`.
+The full list of supported preference strings can be found in [BrowserWindow](browser-window.md#new-browserwindowoptions).
+
+The string follows the same format as the features string in `window.open`.
+A name by itself is given a `true` boolean value.
+A preference can be set to another value by including an `=`, followed by the value.
+Special values `yes` and `1` are interpreted as `true`, while `no` and `0` are interpreted as `false`.  
+
+### `blinkfeatures`
+
+```html
+<webview src="https://www.github.com/" blinkfeatures="PreciseMemoryInfo, CSSVariables"></webview>
+```
+
+A list of strings which specifies the blink features to be enabled separated by `,`.
+The full list of supported feature strings can be found in the
+[RuntimeEnabledFeatures.in][blink-feature-string] file.
+
+### `disableblinkfeatures`
+
+```html
+<webview src="https://www.github.com/" disableblinkfeatures="PreciseMemoryInfo, CSSVariables"></webview>
+```
+
+A list of strings which specifies the blink features to be disabled separated by `,`.
+The full list of supported feature strings can be found in the
+[RuntimeEnabledFeatures.in][blink-feature-string] file.
+
+### `guestinstance`
+
+```html
+<webview src="https://www.github.com/" guestinstance="3"></webview>
+```
+
+A value that links the webview to a specific webContents. When a webview
+first loads a new webContents is created and this attribute is set to its
+instance identifier. Setting this attribute on a new or existing webview
+connects it to the existing webContents that currently renders in a different
+webview.
+
+The existing webview will see the `destroy` event and will then create a new
+webContents when a new url is loaded.
+
+## Methods
+
+The `webview` tag has the following methods:
+
+**Note:** The webview element must be loaded before using the methods.
+
+**Example**
+
+```javascript
+const webview = document.getElementById('foo')
+webview.addEventListener('dom-ready', () => {
+  webview.openDevTools()
+})
+```
+
+### `<webview>.loadURL(url[, options])`
+
+* `url` URL
+* `options` Object (optional)
+  * `httpReferrer` String - A HTTP Referrer url.
+  * `userAgent` String - A user agent originating the request.
+  * `extraHeaders` String - Extra headers separated by "\n"
+
+Loads the `url` in the webview, the `url` must contain the protocol prefix,
+e.g. the `http://` or `file://`.
+
+### `<webview>.getURL()`
+
+Returns `String` - The URL of guest page.
+
+### `<webview>.getTitle()`
+
+Returns `String` - The title of guest page.
+
+### `<webview>.isLoading()`
+
+Returns `Boolean` - Whether guest page is still loading resources.
+
+### `<webview>.isWaitingForResponse()`
+
+Returns `Boolean` - Whether the guest page is waiting for a first-response for the
+main resource of the page.
+
+### `<webview>.stop()`
+
+Stops any pending navigation.
+
+### `<webview>.reload()`
+
+Reloads the guest page.
+
+### `<webview>.reloadIgnoringCache()`
+
+Reloads the guest page and ignores cache.
+
+### `<webview>.canGoBack()`
+
+Returns `Boolean` - Whether the guest page can go back.
+
+### `<webview>.canGoForward()`
+
+Returns `Boolean` - Whether the guest page can go forward.
+
+### `<webview>.canGoToOffset(offset)`
+
+* `offset` Integer
+
+Returns `Boolean` - Whether the guest page can go to `offset`.
+
+### `<webview>.clearHistory()`
+
+Clears the navigation history.
+
+### `<webview>.goBack()`
+
+Makes the guest page go back.
+
+### `<webview>.goForward()`
+
+Makes the guest page go forward.
+
+### `<webview>.goToIndex(index)`
+
+* `index` Integer
+
+Navigates to the specified absolute index.
+
+### `<webview>.goToOffset(offset)`
+
+* `offset` Integer
+
+Navigates to the specified offset from the "current entry".
+
+### `<webview>.isCrashed()`
+
+Returns `Boolean` - Whether the renderer process has crashed.
+
+### `<webview>.setUserAgent(userAgent)`
+
+* `userAgent` String
+
+Overrides the user agent for the guest page.
+
+### `<webview>.getUserAgent()`
+
+Returns `String` - The user agent for guest page.
+
+### `<webview>.insertCSS(css)`
+
+* `css` String
+
+Injects CSS into the guest page.
+
+### `<webview>.executeJavaScript(code, userGesture, callback)`
+
+* `code` String
+* `userGesture` Boolean - Default `false`.
+* `callback` Function (optional) - Called after script has been executed.
+  * `result` Any
+
+Evaluates `code` in page. If `userGesture` is set, it will create the user
+gesture context in the page. HTML APIs like `requestFullScreen`, which require
+user action, can take advantage of this option for automation.
+
+### `<webview>.openDevTools()`
+
+Opens a DevTools window for guest page.
+
+### `<webview>.closeDevTools()`
+
+Closes the DevTools window of guest page.
+
+### `<webview>.isDevToolsOpened()`
+
+Returns `Boolean` - Whether guest page has a DevTools window attached.
+
+### `<webview>.isDevToolsFocused()`
+
+Returns `Boolean` - Whether DevTools window of guest page is focused.
+
+### `<webview>.inspectElement(x, y)`
+
+* `x` Integer
+* `y` Integer
+
+Starts inspecting element at position (`x`, `y`) of guest page.
+
+### `<webview>.inspectServiceWorker()`
+
+Opens the DevTools for the service worker context present in the guest page.
+
+### `<webview>.setAudioMuted(muted)`
+
+* `muted` Boolean
+
+Set guest page muted.
+
+### `<webview>.isAudioMuted()`
+
+Returns `Boolean` - Whether guest page has been muted.
+
+### `<webview>.undo()`
+
+Executes editing command `undo` in page.
+
+### `<webview>.redo()`
+
+Executes editing command `redo` in page.
+
+### `<webview>.cut()`
+
+Executes editing command `cut` in page.
+
+### `<webview>.copy()`
+
+Executes editing command `copy` in page.
+
+### `<webview>.paste()`
+
+Executes editing command `paste` in page.
+
+### `<webview>.pasteAndMatchStyle()`
+
+Executes editing command `pasteAndMatchStyle` in page.
+
+### `<webview>.delete()`
+
+Executes editing command `delete` in page.
+
+### `<webview>.selectAll()`
+
+Executes editing command `selectAll` in page.
+
+### `<webview>.unselect()`
+
+Executes editing command `unselect` in page.
+
+### `<webview>.replace(text)`
+
+* `text` String
+
+Executes editing command `replace` in page.
+
+### `<webview>.replaceMisspelling(text)`
+
+* `text` String
+
+Executes editing command `replaceMisspelling` in page.
+
+### `<webview>.insertText(text)`
+
+* `text` String
+
+Inserts `text` to the focused element.
+
+### `<webview>.findInPage(text[, options])`
+
+* `text` String - Content to be searched, must not be empty.
+* `options` Object (optional)
+  * `forward` Boolean - Whether to search forward or backward, defaults to `true`.
+  * `findNext` Boolean - Whether the operation is first request or a follow up,
+    defaults to `false`.
+  * `matchCase` Boolean - Whether search should be case-sensitive,
+    defaults to `false`.
+  * `wordStart` Boolean - Whether to look only at the start of words.
+    defaults to `false`.
+  * `medialCapitalAsWordStart` Boolean - When combined with `wordStart`,
+    accepts a match in the middle of a word if the match begins with an
+    uppercase letter followed by a lowercase or non-letter.
+    Accepts several other intra-word matches, defaults to `false`.
+
+Starts a request to find all matches for the `text` in the web page and returns an `Integer`
+representing the request id used for the request. The result of the request can be
+obtained by subscribing to [`found-in-page`](web-view-tag.md#event-found-in-page) event.
+
+### `<webview>.stopFindInPage(action)`
+
+* `action` String - Specifies the action to take place when ending
+  [`<webview>.findInPage`](web-view-tag.md#webviewtagfindinpage) request.
+  * `clearSelection` - Clear the selection.
+  * `keepSelection` - Translate the selection into a normal selection.
+  * `activateSelection` - Focus and click the selection node.
+
+Stops any `findInPage` request for the `webview` with the provided `action`.
+
+### `<webview>.print([options])`
+
+Prints `webview`'s web page. Same as `webContents.print([options])`.
+
+### `<webview>.printToPDF(options, callback)`
+
+Prints `webview`'s web page as PDF, Same as `webContents.printToPDF(options, callback)`.
+
+### `<webview>.capturePage([rect, ]callback)`
+
+Captures a snapshot of the `webview`'s page. Same as `webContents.capturePage([rect, ]callback)`.
+
+### `<webview>.send(channel[, arg1][, arg2][, ...])`
+
+* `channel` String
+* `arg` (optional)
+
+Send an asynchronous message to renderer process via `channel`, you can also
+send arbitrary arguments. The renderer process can handle the message by
+listening to the `channel` event with the `ipcRenderer` module.
+
+See [webContents.send](web-contents.md#webcontentssendchannel-args) for
+examples.
+
+### `<webview>.sendInputEvent(event)`
+
+* `event` Object
+
+Sends an input `event` to the page.
+
+See [webContents.sendInputEvent](web-contents.md#webcontentssendinputeventevent)
+for detailed description of `event` object.
+
+### `<webview>.setZoomFactor(factor)`
+
+* `factor` Number - Zoom factor.
+
+Changes the zoom factor to the specified factor. Zoom factor is
+zoom percent divided by 100, so 300% = 3.0.
+
+### `<webview>.setZoomLevel(level)`
+
+* `level` Number - Zoom level
+
+Changes the zoom level to the specified level. The original size is 0 and each
+increment above or below represents zooming 20% larger or smaller to default
+limits of 300% and 50% of original size, respectively.
+
+### `<webview>.showDefinitionForSelection()` _macOS_
+
+Shows pop-up dictionary that searches the selected word on the page.
+
+### `<webview>.getWebContents()`
+
+Returns `WebContents` - The [WebContents](web-contents.md) associated with this `webview`.
+
+## DOM events
+
+The following DOM events are available to the `webview` tag:
+
+### Event: 'load-commit'
+
+Returns:
+
+* `url` String
+* `isMainFrame` Boolean
+
+Fired when a load has committed. This includes navigation within the current
+document as well as subframe document-level loads, but does not include
+asynchronous resource loads.
+
+### Event: 'did-finish-load'
+
+Fired when the navigation is done, i.e. the spinner of the tab will stop
+spinning, and the `onload` event is dispatched.
+
+### Event: 'did-fail-load'
+
+Returns:
+
+* `errorCode` Integer
+* `errorDescription` String
+* `validatedURL` String
+* `isMainFrame` Boolean
+
+This event is like `did-finish-load`, but fired when the load failed or was
+cancelled, e.g. `window.stop()` is invoked.
+
+### Event: 'did-frame-finish-load'
+
+Returns:
+
+* `isMainFrame` Boolean
+
+Fired when a frame has done navigation.
+
+### Event: 'did-start-loading'
+
+Corresponds to the points in time when the spinner of the tab starts spinning.
+
+### Event: 'did-stop-loading'
+
+Corresponds to the points in time when the spinner of the tab stops spinning.
+
+### Event: 'did-get-response-details'
+
+Returns:
+
+* `status` Boolean
+* `newURL` String
+* `originalURL` String
+* `httpResponseCode` Integer
+* `requestMethod` String
+* `referrer` String
+* `headers` Object
+* `resourceType` String
+
+Fired when details regarding a requested resource is available.
+`status` indicates socket connection to download the resource.
+
+### Event: 'did-get-redirect-request'
+
+Returns:
+
+* `oldURL` String
+* `newURL` String
+* `isMainFrame` Boolean
+
+Fired when a redirect was received while requesting a resource.
+
+### Event: 'dom-ready'
+
+Fired when document in the given frame is loaded.
+
+### Event: 'page-title-updated'
+
+Returns:
+
+* `title` String
+* `explicitSet` Boolean
+
+Fired when page title is set during navigation. `explicitSet` is false when
+title is synthesized from file url.
+
+### Event: 'page-favicon-updated'
+
+Returns:
+
+* `favicons` String[] - Array of URLs.
+
+Fired when page receives favicon urls.
+
+### Event: 'enter-html-full-screen'
+
+Fired when page enters fullscreen triggered by HTML API.
+
+### Event: 'leave-html-full-screen'
+
+Fired when page leaves fullscreen triggered by HTML API.
+
+### Event: 'console-message'
+
+Returns:
+
+* `level` Integer
+* `message` String
+* `line` Integer
+* `sourceId` String
+
+Fired when the guest window logs a console message.
+
+The following example code forwards all log messages to the embedder's console
+without regard for log level or other properties.
+
+```javascript
+const webview = document.getElementById('foo')
+webview.addEventListener('console-message', (e) => {
+  console.log('Guest page logged a message:', e.message)
+})
+```
+
+### Event: 'found-in-page'
+
+Returns:
+
+* `result` Object
+  * `requestId` Integer
+  * `activeMatchOrdinal` Integer - Position of the active match.
+  * `matches` Integer - Number of Matches.
+  * `selectionArea` Object - Coordinates of first match region.
+
+Fired when a result is available for
+[`webview.findInPage`](web-view-tag.md#webviewtagfindinpage) request.
+
+```javascript
+const webview = document.getElementById('foo')
+webview.addEventListener('found-in-page', (e) => {
+  webview.stopFindInPage('keepSelection')
+})
+
+const requestId = webview.findInPage('test')
+console.log(requestId)
+```
+
+### Event: 'new-window'
+
+Returns:
+
+* `url` String
+* `frameName` String
+* `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,
+  `new-window`, `save-to-disk` and `other`.
+* `options` Object - The options which should be used for creating the new
+  `BrowserWindow`.
+
+Fired when the guest page attempts to open a new browser window.
+
+The following example code opens the new url in system's default browser.
+
+```javascript
+const {shell} = require('electron')
+const webview = document.getElementById('foo')
+
+webview.addEventListener('new-window', (e) => {
+  const protocol = require('url').parse(e.url).protocol
+  if (protocol === 'http:' || protocol === 'https:') {
+    shell.openExternal(e.url)
+  }
+})
+```
+
+### Event: 'will-navigate'
+
+Returns:
+
+* `url` String
+
+Emitted when a user or the page wants to start navigation. It can happen when
+the `window.location` object is changed or a user clicks a link in the page.
+
+This event will not emit when the navigation is started programmatically with
+APIs like `<webview>.loadURL` and `<webview>.back`.
+
+It is also not emitted during in-page navigation, such as clicking anchor links
+or updating the `window.location.hash`. Use `did-navigate-in-page` event for
+this purpose.
+
+Calling `event.preventDefault()` does __NOT__ have any effect.
+
+### Event: 'did-navigate'
+
+Returns:
+
+* `url` String
+
+Emitted when a navigation is done.
+
+This event is not emitted for in-page navigations, such as clicking anchor links
+or updating the `window.location.hash`. Use `did-navigate-in-page` event for
+this purpose.
+
+### Event: 'did-navigate-in-page'
+
+Returns:
+
+* `isMainFrame` Boolean
+* `url` String
+
+Emitted when an in-page navigation happened.
+
+When in-page navigation happens, the page URL changes but does not cause
+navigation outside of the page. Examples of this occurring are when anchor links
+are clicked or when the DOM `hashchange` event is triggered.
+
+### Event: 'close'
+
+Fired when the guest page attempts to close itself.
+
+The following example code navigates the `webview` to `about:blank` when the
+guest attempts to close itself.
+
+```javascript
+const webview = document.getElementById('foo')
+webview.addEventListener('close', () => {
+  webview.src = 'about:blank'
+})
+```
+
+### Event: 'ipc-message'
+
+Returns:
+
+* `channel` String
+* `args` Array
+
+Fired when the guest page has sent an asynchronous message to embedder page.
+
+With `sendToHost` method and `ipc-message` event you can easily communicate
+between guest page and embedder page:
+
+```javascript
+// In embedder page.
+const webview = document.getElementById('foo')
+webview.addEventListener('ipc-message', (event) => {
+  console.log(event.channel)
+  // Prints "pong"
+})
+webview.send('ping')
+```
+
+```javascript
+// In guest page.
+const {ipcRenderer} = require('electron')
+ipcRenderer.on('ping', () => {
+  ipcRenderer.sendToHost('pong')
+})
+```
+
+### Event: 'crashed'
+
+Fired when the renderer process is crashed.
+
+### Event: 'gpu-crashed'
+
+Fired when the gpu process is crashed.
+
+### Event: 'plugin-crashed'
+
+Returns:
+
+* `name` String
+* `version` String
+
+Fired when a plugin process is crashed.
+
+### Event: 'destroyed'
+
+Fired when the WebContents is destroyed.
+
+### Event: 'media-started-playing'
+
+Emitted when media starts playing.
+
+### Event: 'media-paused'
+
+Emitted when media is paused or done playing.
+
+### Event: 'did-change-theme-color'
+
+Returns:
+
+* `themeColor` String
+
+Emitted when a page's theme color changes. This is usually due to encountering a meta tag:
+
+```html
+<meta name='theme-color' content='#ff0000'>
+```
+
+### Event: 'update-target-url'
+
+Returns:
+
+* `url` String
+
+Emitted when mouse moves over a link or the keyboard moves the focus to a link.
+
+### Event: 'devtools-opened'
+
+Emitted when DevTools is opened.
+
+### Event: 'devtools-closed'
+
+Emitted when DevTools is closed.
+
+### Event: 'devtools-focused'
+
+Emitted when DevTools is focused / opened.
+
+[blink-feature-string]: https://cs.chromium.org/chromium/src/third_party/WebKit/Source/platform/RuntimeEnabledFeatures.in

--- a/test/fixtures/electron/docs/api/window-open.md
+++ b/test/fixtures/electron/docs/api/window-open.md
@@ -1,0 +1,96 @@
+# `window.open` Function
+
+> Open a new window and load a URL.
+
+When `window.open` is called to create a new window in a web page, a new instance
+of `BrowserWindow` will be created for the `url` and a proxy will be returned
+to `window.open` to let the page have limited control over it.
+
+The proxy has limited standard functionality implemented to be
+compatible with traditional web pages. For full control of the new window
+you should create a `BrowserWindow` directly.
+
+The newly created `BrowserWindow` will inherit the parent window's options by
+default. To override inherited options you can set them in the `features`
+string.
+
+### `window.open(url[, frameName][, features])`
+
+* `url` String
+* `frameName` String (optional)
+* `features` String (optional)
+
+Returns `BrowserWindowProxy` - Creates a new window and returns an instance of `BrowserWindowProxy` class.
+
+The `features` string follows the format of standard browser, but each feature
+has to be a field of `BrowserWindow`'s options.
+
+**Notes:**
+
+* Node integration will always be disabled in the opened `window` if it is
+  disabled on the parent window.
+* Non-standard features (that are not handled by Chromium or Electron) given in
+  `features` will be passed to any registered `webContent`'s `new-window` event
+  handler in the `additionalFeatures` argument.
+
+### `window.opener.postMessage(message, targetOrigin)`
+
+* `message` String
+* `targetOrigin` String
+
+Sends a message to the parent window with the specified origin or `*` for no
+origin preference.
+
+## Class: BrowserWindowProxy
+
+> Manipulate the child browser window
+
+Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+
+The `BrowserWindowProxy` object is returned from `window.open` and provides
+limited functionality with the child window.
+
+### Instance Methods
+
+The `BrowserWindowProxy` object has the following instance methods:
+
+#### `win.blur()`
+
+Removes focus from the child window.
+
+#### `win.close()`
+
+Forcefully closes the child window without calling its unload event.
+
+#### `win.eval(code)`
+
+* `code` String
+
+Evaluates the code in the child window.
+
+#### `win.focus()`
+
+Focuses the child window (brings the window to front).
+
+#### `win.print()`
+
+Invokes the print dialog on the child window.
+
+#### `win.postMessage(message, targetOrigin)`
+
+* `message` String
+* `targetOrigin` String
+
+Sends a message to the child window with the specified origin or `*` for no
+origin preference.
+
+In addition to these methods, the child window implements `window.opener` object
+with no properties and a single method.
+
+### Instance Properties
+
+The `BrowserWindowProxy` object has the following instance properties:
+
+#### `win.closed`
+
+A Boolean that is set to true after the child window gets closed.

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ describe('APIs', function () {
   this.timeout(10 * 1000)
 
   before(function (done) {
-    var docPath = path.join(__dirname, '../vendor/electron/docs/api')
+    var docPath = path.join(__dirname, 'fixtures/electron/docs/api')
     lint(docPath, '1.2.3')
       .then(function (_apis) {
         apis = _apis


### PR DESCRIPTION
This PR does away with the `electron/electron` submodule and replaces it with a small script that downloads just the docs (instead of the entire electron repo) to `test/fixtures`.

This also adds a contributing guide.

cc @MarshallOfSound 