### PR TITLE
include electron version property in serialized output

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -104,6 +104,7 @@ class API {
       'name',
       'description',
       'process',
+      'version',
       'type',
       'slug',
       'websiteUrl',

--- a/test/index.js
+++ b/test/index.js
@@ -392,6 +392,7 @@ describe('APIs', function () {
       expect(app.slug).to.exist
       expect(app.websiteUrl).to.exist
       expect(app.repoUrl).to.exist
+      expect(app.version).to.exist
 
       // unwanted
       expect(app.errors).to.not.exist


### PR DESCRIPTION
Use `apis[0].version` to get it.

cc @MarshallOfSound 