### PR TITLE
Add default values for docs path and version

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -6,8 +6,8 @@ const dedent = require('dedent')
 const lint = require('.')
 const args = require('minimist')(process.argv.slice(2))
 
-var docsPath = args._[0]
-var version = args.version
+var docsPath = args._[0] || 'docs/api'
+var version = args.version || process.env.npm_package_version
 var outfile = args.outfile
 
 // docsPath is required


### PR DESCRIPTION
This removes configuration needed in https://github.com/electron/electron/blob/cd8b7f5219b2c827f2bd4d0c7d1f09115a042212/package.json#L40 by defaulting to the expected values.

These assumptions feel okay to me to default to since this is an electron-specific docs linter.

/cc @zeke 

Refs https://github.com/electron/electron/pull/8016