### PR TITLE
Parse the webview doc

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,8 +58,13 @@ function deriveSeeds (docs) {
       const moduleHeading = /^# (.*)/
       const moduleHeadingMatch = doc.markdown_content.match(moduleHeading)
       if (moduleHeadingMatch) {
+        var name = moduleHeadingMatch[1].replace(/ Object/, '')
+
+        // Special case for '<webview> Tag' heading
+        if (name.match(/webview/i)) name = 'webviewTag'
+
         seeds.push({
-          name: moduleHeadingMatch[1].replace(/ Object/, ''),
+          name: name,
           structure: !!doc.filename.match('structures')
         })
       }

--- a/lib/api.js
+++ b/lib/api.js
@@ -12,7 +12,7 @@ const Collection = require('./collection')
 class API {
   constructor (props, docs) {
     Object.assign(this, props)
-    this.slug = decamelize(this.name, '-')
+    this.slug = this.parseSlug()
     this.websiteUrl = `http://electron.atom.io/docs/api/${props.structure ? 'structures/' : ''}${this.slug}`
     this.repoUrl = `https://github.com/electron/electron/blob/v${this.version}/docs/api/${props.structure ? 'structures/' : ''}${this.slug}.md`
     this.type = props.structure ? 'Structure' : (this.name.charAt(0) === this.name.charAt(0).toLowerCase()) ? 'Module' : 'Class'
@@ -75,7 +75,7 @@ class API {
   // as there are headings in the source document. If number does not match,
   // then some items in the collection failed to parse properly
   get collectionErrors () {
-    // return cached errors if the were already computed
+    // return cached errors if they were already computed
     if (this._collectionErrors) return this._collectionErrors
 
     var errors = []
@@ -193,6 +193,11 @@ class API {
       main: !!processes.match('Main'),
       renderer: !!processes.match('Renderer')
     }
+  }
+
+  parseSlug() {
+    if (this.name.match(/webview/i)) return 'webview-tag'
+    return decamelize(this.name, '-')
   }
 
   // Apply DOM IDs to H3s that follow a class definition

--- a/lib/api.js
+++ b/lib/api.js
@@ -15,7 +15,7 @@ class API {
     this.slug = this.parseSlug()
     this.websiteUrl = `http://electron.atom.io/docs/api/${props.structure ? 'structures/' : ''}${this.slug}`
     this.repoUrl = `https://github.com/electron/electron/blob/v${this.version}/docs/api/${props.structure ? 'structures/' : ''}${this.slug}.md`
-    this.type = props.structure ? 'Structure' : (this.name.charAt(0) === this.name.charAt(0).toLowerCase()) ? 'Module' : 'Class'
+    this.type = this.parseType(props)
     this.parseDoc(docs)
     this.description = this.parseDescription()
     this.process = this.parseProcesses()
@@ -129,6 +129,13 @@ class API {
     return cleanDeep(pick(this, props))
   }
 
+  parseType (props) {
+    if (props.structure) return 'Structure'
+    if (this.name.match(/webview/i)) return 'Class'
+    if (this.name.charAt(0) === this.name.charAt(0).toLowerCase()) return 'Module'
+    return 'Class'
+  }
+
   parseDoc (docs) {
     this.doc = docs.find(doc => doc.slug === this.slug)
 
@@ -141,7 +148,7 @@ class API {
   }
 
   parseDescription () {
-    if (this.type === 'Class') {
+    if (this.type === 'Class' && this.name !== 'webviewTag') {
       return this.$(`#class-${this.slug.replace(/-/g, '')}`)
         .next('blockquote').find('p').first().text()
     } else {
@@ -168,6 +175,8 @@ class API {
   }
 
   parseInstanceName () {
+    if (this.name === 'webviewTag') return 'webview'
+
     var $heading = (this.$('[id$="instance-methods"]'))
     if (!$heading.length) $heading = this.$('[id$="instance-properties"]')
     if (!$heading.length) return

--- a/lib/api.js
+++ b/lib/api.js
@@ -45,6 +45,7 @@ class API {
       this.instanceMethods = new Collection('Method', this, `h3#class-${this.slug}-instance-methods`, 3)
       this.instanceProperties = new Collection('Property', this, `h3#class-${this.slug}-instance-properties`, 3)
       this.staticMethods = new Collection('Method', this, `h3#class-${this.slug}-static-methods`, 3)
+      this.attributes = new Collection('Attribute', this, `h2#tag-attributes`, 2)
       this.constructorMethod = this.parseConstructor()
       this.instanceName = this.parseInstanceName()
     }

--- a/lib/api.js
+++ b/lib/api.js
@@ -147,10 +147,6 @@ class API {
     }
 
     this.$ = marky(this.doc.markdown_content)
-
-    if (this.name === 'webviewTag') {
-      console.log(this.$.html())
-    }
   }
 
   parseDescription () {

--- a/lib/api.js
+++ b/lib/api.js
@@ -195,7 +195,7 @@ class API {
     }
   }
 
-  parseSlug() {
+  parseSlug () {
     if (this.name.match(/webview/i)) return 'webview-tag'
     return decamelize(this.name, '-')
   }

--- a/lib/api.js
+++ b/lib/api.js
@@ -45,10 +45,13 @@ class API {
       this.instanceMethods = new Collection('Method', this, `h3#instance-methods`, 3)
       this.instanceProperties = new Collection('Property', this, `h3#instance-properties`, 3)
       this.staticMethods = new Collection('Method', this, `h3#static-methods`, 3)
-      this.methods = new Collection('Method', this, `h2#methods`, 2)
-      this.attributes = new Collection('Attribute', this, `h2#tag-attributes`, 2)
       this.constructorMethod = this.parseConstructor()
       this.instanceName = this.parseInstanceName()
+    }
+
+    if (this.type === 'Element') {
+      this.methods = new Collection('Method', this, `h2#methods`, 2)
+      this.attributes = new Collection('Attribute', this, `h2#tag-attributes`, 2)
     }
 
     if (this.type === 'Structure') {
@@ -134,7 +137,7 @@ class API {
 
   parseType (props) {
     if (props.structure) return 'Structure'
-    if (this.name.match(/webview/i)) return 'Class'
+    if (this.name.match(/webview/i)) return 'Element'
     if (this.name.charAt(0) === this.name.charAt(0).toLowerCase()) return 'Module'
     return 'Class'
   }

--- a/lib/api.js
+++ b/lib/api.js
@@ -124,7 +124,8 @@ class API {
       'instanceMethods',
       'instanceProperties',
       'instanceEvents',
-      'properties'
+      'properties',
+      'attributes'
     ]
 
     return cleanDeep(pick(this, props))

--- a/lib/api.js
+++ b/lib/api.js
@@ -45,6 +45,7 @@ class API {
       this.instanceMethods = new Collection('Method', this, `h3#instance-methods`, 3)
       this.instanceProperties = new Collection('Property', this, `h3#instance-properties`, 3)
       this.staticMethods = new Collection('Method', this, `h3#static-methods`, 3)
+      this.methods = new Collection('Method', this, `h2#methods`, 2)
       this.attributes = new Collection('Attribute', this, `h2#tag-attributes`, 2)
       this.constructorMethod = this.parseConstructor()
       this.instanceName = this.parseInstanceName()

--- a/lib/api.js
+++ b/lib/api.js
@@ -41,10 +41,10 @@ class API {
     }
 
     if (this.type === 'Class') {
-      this.instanceEvents = new Collection('Event', this, `h3#class-${this.slug}-instance-events`, 3)
-      this.instanceMethods = new Collection('Method', this, `h3#class-${this.slug}-instance-methods`, 3)
-      this.instanceProperties = new Collection('Property', this, `h3#class-${this.slug}-instance-properties`, 3)
-      this.staticMethods = new Collection('Method', this, `h3#class-${this.slug}-static-methods`, 3)
+      this.instanceEvents = new Collection('Event', this, `h3#instance-events`, 3)
+      this.instanceMethods = new Collection('Method', this, `h3#instance-methods`, 3)
+      this.instanceProperties = new Collection('Property', this, `h3#instance-properties`, 3)
+      this.staticMethods = new Collection('Method', this, `h3#static-methods`, 3)
       this.attributes = new Collection('Attribute', this, `h2#tag-attributes`, 2)
       this.constructorMethod = this.parseConstructor()
       this.instanceName = this.parseInstanceName()
@@ -145,7 +145,10 @@ class API {
     }
 
     this.$ = marky(this.doc.markdown_content)
-    this.classifyInstanceHeadings()
+
+    if (this.name === 'webviewTag') {
+      console.log(this.$.html())
+    }
   }
 
   parseDescription () {
@@ -208,37 +211,6 @@ class API {
   parseSlug () {
     if (this.name.match(/webview/i)) return 'webview-tag'
     return decamelize(this.name, '-')
-  }
-
-  // Apply DOM IDs to H3s that follow a class definition
-  //
-  // Examples:
-  // class-WebContents-instance-properties
-  // class-Debugger-instance-methods
-  // class-Debugger-instance-events
-  // class-BrowserWindowProxy-instance-methods
-  //
-  classifyInstanceHeadings () {
-    let $ = this.$
-    let classHeadingPattern = /^Class: (.*)$/
-    let knownInstanceLabels = Collection.types.map(type => decamelize(type, '-'))
-    let lastClassName = null
-    $('h2,h3').each(function (i, el) {
-      let tag = $(el).get(0).name
-      let match = $(el).text().match(classHeadingPattern)
-
-      if (tag === 'h2') {
-        lastClassName = match ? decamelize(match[1], '-') : null
-      }
-
-      if (tag === 'h3' && lastClassName) {
-        let instanceLabel = $(el).text().toLowerCase().replace(/\s+/g, '-')
-        if (knownInstanceLabels.indexOf(instanceLabel) > -1) {
-          let id = `class-${lastClassName}-${instanceLabel}`
-          $(el).attr('id', id)
-        }
-      }
-    })
   }
 }
 

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -8,8 +8,6 @@ module.exports = class Attribute extends CollectionItem {
   constructor (api, el) {
     super(api, el, pattern, props)
 
-    console.log('hello from attribute constructor')
-
     if (this.match) {
       this.name = this.match[1]
       this.description = this.getDescription()

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const CollectionItem = require('./collection-item')
+const pattern = /<code>(.*)<\/code>/
+const props = ['name', 'description', 'platforms']
+
+module.exports = class Attribute extends CollectionItem {
+  constructor (api, el) {
+    super(api, el, pattern, props)
+
+    console.log('hello from attribute constructor')
+
+    if (this.match) {
+      this.name = this.match[1]
+      this.description = this.getDescription()
+      this.platforms = this.getPlatforms()
+    }
+
+    return this
+  }
+}

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -4,7 +4,8 @@ const decamelize = require('decamelize')
 const CollectionItemTypes = {
   Event: require('./event'),
   Method: require('./method'),
-  Property: require('./property')
+  Property: require('./property'),
+  Attribute: require('./attribute')
 }
 
 class Collection {
@@ -37,7 +38,8 @@ Collection.types = [
   'instanceEvents',
   'instanceMethods',
   'instanceProperties',
-  'staticMethods'
+  'staticMethods',
+  'attributes'
 ]
 
 module.exports = Collection

--- a/lib/method.js
+++ b/lib/method.js
@@ -21,7 +21,9 @@ module.exports = class Method extends CollectionItem {
         this.name = subProp[1]
         this._superObject = subProp[0]
       } else if (subProp.length > 2) {
-        api.addError('Deep sub property', pattern, el)
+        console.error('Problem parsing deep subproperty')
+        console.error(`pattern: ${pattern}`)
+        console.error(`el: ${el}`)
       }
       // derive an array of parameter names from the method signature;
       // used only in tests to verify that all parameters are documented

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -64,9 +64,8 @@ const getPossibleValues = ($, el, description, api) => {
     .map((i, el) => {
       var match = $(el).html().match(enumPattern)
       if (!match) {
-        console.error('parameter ENUM values')
-        console.error(`enumPattern: ${enumPattern}`)
-        console.error(`el: ${el}`)
+        console.error('Problem parsing parameter ENUM values:')
+        console.error($(el).html())
         return
       }
       return {

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -63,7 +63,12 @@ const getPossibleValues = ($, el, description, api) => {
     .find('li')
     .map((i, el) => {
       var match = $(el).html().match(enumPattern)
-      if (!match) return api.addError('parameter ENUM values', enumPattern, $(el))
+      if (!match) {
+        console.error('parameter ENUM values')
+        console.error(`enumPattern: ${enumPattern}`)
+        console.error(`el: ${el}`)
+        return
+      }
       return {
         value: match[1],
         description: sanitizeDescription(match[2])
@@ -93,7 +98,12 @@ const generateObjectProps = ($, topUL, api) => {
   return topUL.find('> li')
     .map((i, el) => {
       var match = $(el).html().match(parameterPattern)
-      if (!match) return api.addError('parameter subproperties', parameterPattern, $(el))
+      if (!match) {
+        console.error('parameter subproperties')
+        console.error(`parameterPattern: ${parameterPattern}`)
+        console.error(`el: ${el}`)
+        return
+      }
       let parameters
       let properties
       let possibleValues
@@ -206,8 +216,13 @@ module.exports = {
         var match = $(el).html()
           .match(parameterPattern)
 
-        // // Parsing error
-        if (!match) return api.addError('parameters', parameterPattern, $(el))
+        // Parsing error
+        if (!match) {
+          console.error('problem parsing parameters')
+          console.error(`parameterPattern: ${parameterPattern}`)
+          console.error(`el: ${el}`)
+          return
+        }
 
         // Preserve backticks
         var description = preserveBackTicks(match[3])

--- a/lib/schemata.js
+++ b/lib/schemata.js
@@ -10,7 +10,7 @@ const commonSchema = {
     type: {
       type: 'string',
       required: true,
-      enum: ['Class', 'Module', 'Structure']
+      enum: ['Class', 'Module', 'Structure', 'Element']
     }
   }
 }
@@ -75,8 +75,21 @@ const classSchema = {
   }
 }
 
+const elementSchema = {
+  properties: {
+    methods: {
+      type: 'array'
+    },
+    attributes: {
+      type: 'array',
+      allowEmpty: false
+    }
+  }
+}
+
 module.exports = {
   Structure: merge({}, commonSchema),
   Module: merge({}, commonSchema, apiSchema, moduleSchema),
-  Class: merge({}, commonSchema, apiSchema, classSchema)
+  Class: merge({}, commonSchema, apiSchema, classSchema),
+  Element: merge({}, commonSchema, apiSchema, elementSchema)
 }

--- a/test/fixtures/electron/docs/api/app.md
+++ b/test/fixtures/electron/docs/api/app.md
@@ -127,7 +127,7 @@ Returns:
 
 Emitted when the application is activated. Various actions can trigger
 this event, such as launching the application for the first time, attempting
-to re-launch the application when it's already running, or clicking on the 
+to re-launch the application when it's already running, or clicking on the
 application's dock or taskbar icon.
 
 ### Event: 'continue-activity' _macOS_
@@ -820,11 +820,11 @@ Returns `Object`:
     `app.getLoginItemStatus().wasOpenedAsHidden` should be checked when the app
     is opened to know the current value. This setting is only supported on
     macOS.
-  * `path` String (optional) _Windows_ - The executable to launch at login.
-    Defaults to `process.execPath`.
-  * `args` String[] (optional) _Windows_ - The command-line arguments to pass to
-    the executable. Defaults to an empty array. Take care to wrap paths in
-    quotes.
+* `path` String (optional) _Windows_ - The executable to launch at login.
+  Defaults to `process.execPath`.
+* `args` String[] (optional) _Windows_ - The command-line arguments to pass to
+  the executable. Defaults to an empty array. Take care to wrap paths in
+  quotes.
 
 Set the app's login item settings.
 

--- a/test/fixtures/electron/docs/api/app.md
+++ b/test/fixtures/electron/docs/api/app.md
@@ -2,7 +2,7 @@
 
 > Control your application's event lifecycle.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 The following example shows how to quit the application when the last window is
 closed:
@@ -60,6 +60,10 @@ Emitted before the application starts closing its windows.
 Calling `event.preventDefault()` will prevent the default behaviour, which is
 terminating the application.
 
+**Note:** If application quit was initiated by `autoUpdater.quitAndInstall()`
+then `before-quit` is emitted *after* emitting `close` event on all windows and
+closing them.
+
 ### Event: 'will-quit'
 
 Returns:
@@ -108,8 +112,9 @@ Returns:
 * `event` Event
 * `url` String
 
-Emitted when the user wants to open a URL with the application. The URL scheme
-must be registered to be opened by your application.
+Emitted when the user wants to open a URL with the application. Your application's
+`Info.plist` file must define the url scheme within the `CFBundleURLTypes` key, and
+set `NSPrincipalClass` to `AtomApplication`.
 
 You should call `event.preventDefault()` if you want to handle this event.
 
@@ -120,8 +125,10 @@ Returns:
 * `event` Event
 * `hasVisibleWindows` Boolean
 
-Emitted when the application is activated, which usually happens when the user
-clicks on the application's dock icon.
+Emitted when the application is activated. Various actions can trigger
+this event, such as launching the application for the first time, attempting
+to re-launch the application when it's already running, or clicking on the 
+application's dock or taskbar icon.
 
 ### Event: 'continue-activity' _macOS_
 
@@ -184,7 +191,7 @@ Returns:
 
 * `event` Event
 * `webContents` [WebContents](web-contents.md)
-* `url` URL
+* `url` String
 * `error` String - The error code
 * `certificate` [Certificate](structures/certificate.md)
 * `callback` Function
@@ -217,12 +224,12 @@ Returns:
 * `url` URL
 * `certificateList` [Certificate[]](structures/certificate.md)
 * `callback` Function
-  * `certificate` [Certificate](structures/certificate.md)
+  * `certificate` [Certificate](structures/certificate.md) (optional)
 
 Emitted when a client certificate is requested.
 
 The `url` corresponds to the navigation entry requesting the client certificate
-and `callback` needs to be called with an entry filtered from the list. Using
+and `callback` can be called with an entry filtered from the list. Using
 `event.preventDefault()` prevents the application from using the first
 certificate from the store.
 
@@ -321,7 +328,7 @@ and `will-quit` events will not be emitted.
 ### `app.relaunch([options])`
 
 * `options` Object (optional)
-  * `args` String[] (optional)
+  * `args` String[] - (optional)
   * `execPath` String (optional)
 
 Relaunches the app when current instance exits.
@@ -395,6 +402,28 @@ You can request the following paths by the name:
 * `pictures` Directory for a user's pictures.
 * `videos` Directory for a user's videos.
 * `pepperFlashSystemPlugin`  Full path to the system version of the Pepper Flash plugin.
+
+### `app.getFileIcon(path[, options], callback)`
+
+* `path` String
+* `options` Object (optional)
+  * `size` String
+    * `small` - 16x16
+    * `normal` - 32x32
+    * `large` - 48x48 on _Linux_, 32x32 on _Windows_, unsupported on _macOS_.
+* `callback` Function
+  * `error` Error
+  * `icon` [NativeImage](native-image.md)
+
+Fetches a path's associated icon.
+
+On _Windows_, there a 2 kinds of icons:
+
+- Icons associated with certain file extensions, like `.mp3`, `.png`, etc.
+- Icons inside the file itself, like `.exe`, `.dll`, `.ico`.
+
+On _Linux_ and _macOS_, icons depend on the application associated with file
+mime type.
 
 ### `app.setPath(name, path)`
 
@@ -742,8 +771,8 @@ badge.
 
 On macOS it shows on the dock icon. On Linux it only works for Unity launcher,
 
-**Note:** Unity launcher requires the exsistence of a `.desktop` file to work,
-for more information please read [Desktop Environment Integration][unity-requiremnt].
+**Note:** Unity launcher requires the existence of a `.desktop` file to work,
+for more information please read [Desktop Environment Integration][unity-requirement].
 
 ### `app.getBadgeCount()` _Linux_ _macOS_
 
@@ -753,7 +782,16 @@ Returns `Integer` - The current value displayed in the counter badge.
 
 Returns `Boolean` - Whether the current desktop environment is Unity launcher.
 
-### `app.getLoginItemSettings()` _macOS_ _Windows_
+### `app.getLoginItemSettings([options])` _macOS_ _Windows_
+
+* `options` Object (optional)
+  * `path` String (optional) _Windows_ - The executable path to compare against.
+    Defaults to `process.execPath`.
+  * `args` String[] (optional) _Windows_ - The command-line arguments to compare
+    against. Defaults to an empty array.
+
+If you provided `path` and `args` options to `app.setLoginItemSettings` then you
+need to pass the same arguments here for `openAtLogin` to be set correctly.
 
 Returns `Object`:
 
@@ -770,10 +808,9 @@ Returns `Object`:
   app should restore the windows that were open the last time the app was
   closed. This setting is only supported on macOS.
 
-**Note:** This API has no effect on
-[MAS builds][mas-builds].
+**Note:** This API has no effect on [MAS builds][mas-builds].
 
-### `app.setLoginItemSettings(settings)` _macOS_ _Windows_
+### `app.setLoginItemSettings(settings[, path, args])` _macOS_ _Windows_
 
 * `settings` Object
   * `openAtLogin` Boolean (optional) - `true` to open the app at login, `false` to remove
@@ -783,11 +820,34 @@ Returns `Object`:
     `app.getLoginItemStatus().wasOpenedAsHidden` should be checked when the app
     is opened to know the current value. This setting is only supported on
     macOS.
+  * `path` String (optional) _Windows_ - The executable to launch at login.
+    Defaults to `process.execPath`.
+  * `args` String[] (optional) _Windows_ - The command-line arguments to pass to
+    the executable. Defaults to an empty array. Take care to wrap paths in
+    quotes.
 
 Set the app's login item settings.
 
-**Note:** This API has no effect on
-[MAS builds][mas-builds].
+To work with Electron's `autoUpdater` on Windows, which uses [Squirrel][Squirrel-Windows],
+you'll want to set the launch path to Update.exe, and pass arguments that specify your
+application name. For example:
+
+``` javascript
+const appFolder = path.dirname(process.execPath)
+const updateExe = path.resolve(appFolder, '..', 'Update.exe')
+const exeName = path.basename(process.execPath)
+
+app.setLoginItemSettings({
+  openAtLogin: true,
+  path: updateExe,
+  args: [
+    '--processStart', `"${exeName}"`,
+    '--process-start-args', `"--hidden"`
+  ]
+})
+```
+
+**Note:** This API has no effect on [MAS builds][mas-builds].
 
 ### `app.isAccessibilitySupportEnabled()` _macOS_ _Windows_
 
@@ -840,7 +900,7 @@ When `informational` is passed, the dock icon will bounce for one second.
 However, the request remains active until either the application becomes active
 or the request is canceled.
 
-Returns an ID representing the request.
+Returns `Integer` an ID representing the request.
 
 ### `app.dock.cancelBounce(id)` _macOS_
 
@@ -886,7 +946,7 @@ Sets the application's [dock menu][dock-menu].
 
 ### `app.dock.setIcon(image)` _macOS_
 
-* `image` [NativeImage](native-image.md)
+* `image` ([NativeImage](native-image.md) | String)
 
 Sets the `image` associated with this dock icon.
 
@@ -897,7 +957,8 @@ Sets the `image` associated with this dock icon.
 [LSCopyDefaultHandlerForURLScheme]: https://developer.apple.com/library/mac/documentation/Carbon/Reference/LaunchServicesReference/#//apple_ref/c/func/LSCopyDefaultHandlerForURLScheme
 [handoff]: https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/Handoff/HandoffFundamentals/HandoffFundamentals.html
 [activity-type]: https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSUserActivity_Class/index.html#//apple_ref/occ/instp/NSUserActivity/activityType
-[unity-requiremnt]: ../tutorial/desktop-environment-integration.md#unity-launcher-shortcuts-linux
+[unity-requirement]: ../tutorial/desktop-environment-integration.md#unity-launcher-shortcuts-linux
 [mas-builds]: ../tutorial/mac-app-store-submission-guide.md
+[Squirrel-Windows]: https://github.com/Squirrel/Squirrel.Windows
 [JumpListBeginListMSDN]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378398(v=vs.85).aspx
 [about-panel-options]: https://developer.apple.com/reference/appkit/nsapplication/1428479-orderfrontstandardaboutpanelwith?language=objc

--- a/test/fixtures/electron/docs/api/auto-updater.md
+++ b/test/fixtures/electron/docs/api/auto-updater.md
@@ -2,7 +2,7 @@
 
 > Enable apps to automatically update themselves.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 The `autoUpdater` module provides an interface for the
 [Squirrel](https://github.com/Squirrel) framework.
@@ -16,6 +16,7 @@ application by using one of these projects:
   auto-updater*
 - [squirrel-updates-server][squirrel-updates-server]: *A simple node.js server
   for Squirrel.Mac and Squirrel.Windows which uses GitHub releases*
+- [squirrel-release-server][squirrel-release-server]: *A simple PHP application for Squirrel.Windows which reads updates from a folder. Supports delta updates.*
 
 ## Platform notices
 
@@ -40,7 +41,7 @@ On Windows, you have to install your app into a user's machine before you can
 use the `autoUpdater`, so it is recommended that you use the
 [electron-winstaller][installer-lib], [electron-builder][electron-builder-lib] or the [grunt-electron-installer][installer] package to generate a Windows installer.
 
-When using [electron-winstaller][installer-lib] or [electron-builder][electron-builder-lib] make sure you do not try to update your app [the first time it runs](https://github.com/electron/windows-installer#handling-squirrel-events) (Also see [this issue for more info](https://github.com/electron/electron/issues/7155)). It's also recommended to use [electron-squirrel-startup](electron-squirrel-startup) to get desktop shortcuts for your app.
+When using [electron-winstaller][installer-lib] or [electron-builder][electron-builder-lib] make sure you do not try to update your app [the first time it runs](https://github.com/electron/windows-installer#handling-squirrel-events) (Also see [this issue for more info](https://github.com/electron/electron/issues/7155)). It's also recommended to use [electron-squirrel-startup](https://github.com/mongodb-js/electron-squirrel-startup) to get desktop shortcuts for your app.
 
 The installer generated with Squirrel will create a shortcut icon with an
 [Application User Model ID][app-user-model-id] in the format of
@@ -121,6 +122,10 @@ using this API.
 Restarts the app and installs the update after it has been downloaded. It
 should only be called after `update-downloaded` has been emitted.
 
+**Note:** `autoUpdater.quitAndInstall()` will close all application windows
+first and only emit `before-quit` event on `app` after that. This is different
+from the normal quit event sequence.
+
 [squirrel-mac]: https://github.com/Squirrel/Squirrel.Mac
 [server-support]: https://github.com/Squirrel/Squirrel.Mac#server-support
 [squirrel-windows]: https://github.com/Squirrel/Squirrel.Windows
@@ -131,3 +136,4 @@ should only be called after `update-downloaded` has been emitted.
 [electron-release-server]: https://github.com/ArekSredzki/electron-release-server
 [squirrel-updates-server]: https://github.com/Aluxian/squirrel-updates-server
 [nuts]: https://github.com/GitbookIO/nuts
+[squirrel-release-server]: https://github.com/Arcath/squirrel-release-server

--- a/test/fixtures/electron/docs/api/browser-window-proxy.md
+++ b/test/fixtures/electron/docs/api/browser-window-proxy.md
@@ -2,7 +2,7 @@
 
 > Manipulate the child browser window
 
-Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+Process: [Renderer](../glossary.md#renderer-process)
 
 The `BrowserWindowProxy` object is returned from `window.open` and provides
 limited functionality with the child window.

--- a/test/fixtures/electron/docs/api/browser-window.md
+++ b/test/fixtures/electron/docs/api/browser-window.md
@@ -2,7 +2,7 @@
 
 > Create and control browser windows.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 ```javascript
 // In the main process.
@@ -30,8 +30,7 @@ you can use the [Frameless Window](frameless-window.md) API.
 
 ## Showing window gracefully
 
-When loading a page in window directly, users will see the progress of loading
-page, which is not good experience for native app. To make the window display
+When loading a page in the window directly, users may see the page load incrementally, which is not a good experience for a native app. To make the window display
 without visual flash, there are two solutions for different situations.
 
 ### Using `ready-to-show` event
@@ -48,7 +47,7 @@ win.once('ready-to-show', () => {
 })
 ```
 
-This is event is usually emitted after the `did-finish-load` event, but for
+This event is usually emitted after the `did-finish-load` event, but for
 pages with many remote resources, it may be emitted before the `did-finish-load`
 event.
 
@@ -100,6 +99,7 @@ child.once('ready-to-show', () => {
 
 ### Platform notices
 
+* On macOS modal windows will be displayed as sheets attached to the parent window.
 * On macOS the child windows will keep the relative position to parent window
   when parent window moves, while on Windows and Linux child windows will not
   move.
@@ -111,7 +111,7 @@ child.once('ready-to-show', () => {
 
 > Create and control browser windows.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 `BrowserWindow` is an
 [EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter).
@@ -202,9 +202,15 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `thickFrame` Boolean (optional) - Use `WS_THICKFRAME` style for frameless windows on
     Windows, which adds standard window frame. Setting it to `false` will remove
     window shadow and window animations. Default is `true`.
-  * `vibrancy` String - Add a type of vibrancy effect to the window, only on
+  * `vibrancy` String (optional) - Add a type of vibrancy effect to the window, only on
     macOS. Can be `appearance-based`, `light`, `dark`, `titlebar`, `selection`,
     `menu`, `popover`, `sidebar`, `medium-light` or `ultra-dark`.
+  * `zoomToPageWidth` Boolean (optional) - Controls the behavior on macOS when
+    option-clicking the green stoplight button on the toolbar or by clicking the
+    Window > Zoom menu item. If `true`, the window will grow to the preferred
+    width of the web page when zoomed, `false` will cause it to zoom to the
+    width of the screen. This will also affect the behavior when calling
+    `maximize()` directly. Default is `false`.
   * `webPreferences` Object (optional) - Settings of web page's features.
     * `devTools` Boolean (optional) - Whether to enable DevTools. If it is set to `false`, can not use `BrowserWindow.webContents.openDevTools()` to open DevTools. Default is `true`.
     * `nodeIntegration` Boolean (optional) - Whether node integration is enabled. Default
@@ -232,10 +238,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     * `javascript` Boolean (optional) - Enables JavaScript support. Default is `true`.
     * `webSecurity` Boolean (optional) - When `false`, it will disable the
       same-origin policy (usually using testing websites by people), and set
-      `allowDisplayingInsecureContent` and `allowRunningInsecureContent` to
-      `true` if these two options are not set by user. Default is `true`.
-    * `allowDisplayingInsecureContent` Boolean (optional) - Allow an https page to display
-      content like images from http URLs. Default is `false`.
+      `allowRunningInsecureContent` to `true` if this options has not been set
+      by user. Default is `true`.
     * `allowRunningInsecureContent` Boolean (optional) - Allow an https page to run
       JavaScript, CSS or plugins from http URLs. Default is `false`.
     * `images` Boolean (optional) - Enables image support. Default is `true`.
@@ -252,17 +256,19 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       macOS. Default is `false`.
     * `blinkFeatures` String (optional) - A list of feature strings separated by `,`, like
       `CSSVariables,KeyboardEventKey` to enable. The full list of supported feature
-      strings can be found in the [RuntimeEnabledFeatures.in][blink-feature-string]
+      strings can be found in the [RuntimeEnabledFeatures.json5][blink-feature-string]
       file.
     * `disableBlinkFeatures` String (optional) - A list of feature strings separated by `,`,
       like `CSSVariables,KeyboardEventKey` to disable. The full list of supported
       feature strings can be found in the
-      [RuntimeEnabledFeatures.in][blink-feature-string] file.
+      [RuntimeEnabledFeatures.json5][blink-feature-string] file.
     * `defaultFontFamily` Object (optional) - Sets the default font for the font-family.
       * `standard` String (optional) - Defaults to `Times New Roman`.
       * `serif` String (optional) - Defaults to `Times New Roman`.
       * `sansSerif` String (optional) - Defaults to `Arial`.
       * `monospace` String (optional) - Defaults to `Courier New`.
+      * `cursive` String (optional) - Defaults to `Script`.
+      * `fantasy` String (optional) - Defaults to `Impact`.
     * `defaultFontSize` Integer (optional) - Defaults to `16`.
     * `defaultMonospaceFontSize` Integer (optional) - Defaults to `13`.
     * `minimumFontSize` Integer (optional) - Defaults to `0`.
@@ -270,8 +276,25 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     * `backgroundThrottling` Boolean (optional) - Whether to throttle animations and timers
       when the page becomes background. Defaults to `true`.
     * `offscreen` Boolean (optional) - Whether to enable offscreen rendering for the browser
-      window. Defaults to `false`.
+      window. Defaults to `false`. See the
+      [offscreen rendering tutorial](../tutorial/offscreen-rendering.md) for
+      more details.
     * `sandbox` Boolean (optional) - Whether to enable Chromium OS-level sandbox.
+    * `contextIsolation` Boolean (optional) - Whether to run Electron APIs and
+      the specified `preload` script in a separate JavaScript context. Defaults
+      to `false`. The context that the `preload` script runs in will still
+      have full access to the `document` and `window` globals but it will use
+      its own set of JavaScript builtins (`Array`, `Object`, `JSON`, etc.)
+      and will be isolated from any changes made to the global environment
+      by the loaded page. The Electron API will only be available in the
+      `preload` script and not the loaded page. This option should be used when
+      loading potentially untrusted remote content to ensure the loaded content
+      cannot tamper with the `preload` script and any Electron APIs being used.
+      This option uses the same technique used by [Chrome Content Scripts][chrome-content-scripts].
+      You can access this context in the dev tools by selecting the
+      'Electron Isolated Context' entry in the combo box at the top of the
+      Console tab. **Note:** This option is currently experimental and may
+      change or be removed in future Electron releases.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from
@@ -676,6 +699,10 @@ height areas you have within the overall content view.
 
 Uses [Quick Look][quick-look] to preview a file at a given path.
 
+#### `win.closeFilePreview()` _macOS_
+
+Closes the currently open [Quick Look][quick-look] panel.
+
 #### `win.setBounds(bounds[, animate])`
 
 * `bounds` [Rectangle](structures/rectangle.md)
@@ -817,13 +844,16 @@ Returns `Boolean` - Whether the window can be manually closed by user.
 
 On Linux always returns `true`.
 
-#### `win.setAlwaysOnTop(flag[, level])`
+#### `win.setAlwaysOnTop(flag[, level][, relativeLevel])`
 
 * `flag` Boolean
 * `level` String (optional) _macOS_ - Values include `normal`, `floating`,
   `torn-off-menu`, `modal-panel`, `main-menu`, `status`, `pop-up-menu`,
-  `screen-saver`, and `dock`. The default is `floating`. See the
+  `screen-saver`, and ~~`dock`~~ (Deprecated). The default is `floating`. See the
   [macOS docs][window-levels] for more details.
+* `relativeLevel` Integer (optional) _macOS_ - The number of layers higher to set
+  this window relative to the given `level`. The default is `0`. Note that Apple
+  discourages setting levels higher than 1 above `screen-saver`.
 
 Sets whether the window should show always on top of other windows. After
 setting this, the window is still a normal window, not a toolbox window which
@@ -973,7 +1003,7 @@ Same as `webContents.capturePage([rect, ]callback)`.
   * `httpReferrer` String (optional) - A HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
-  * `postData` ([UploadRawData](structures/upload-raw-data.md) | [UploadFile](structures/upload-file.md) | [UploadFileSystem](structures/upload-file-system.md) | [UploadBlob](structures/upload-blob.md))[] (optional)
+  * `postData` ([UploadRawData](structures/upload-raw-data.md) | [UploadFile](structures/upload-file.md) | [UploadFileSystem](structures/upload-file-system.md) | [UploadBlob](structures/upload-blob.md))[] - (optional)
 
 Same as `webContents.loadURL(url[, options])`.
 
@@ -992,6 +1022,19 @@ let url = require('url').format({
 })
 
 win.loadURL(url)
+```
+
+You can load a URL using a `POST` request with URL-encoded data by doing
+the following:
+
+```javascript
+win.loadURL('http://localhost:8000/post', {
+  postData: [{
+    type: 'rawData',
+    bytes: Buffer.from('hello=world')
+  }],
+  extraHeaders: 'Content-Type: application/x-www-form-urlencoded'
+})
 ```
 
 #### `win.reload()`
@@ -1103,6 +1146,22 @@ the entire window by specifying an empty region:
 Sets the toolTip that is displayed when hovering over the window thumbnail
 in the taskbar.
 
+#### `win.setAppDetails(options)` _Windows_
+
+* `options` Object
+  * `appId` String (optional) - Window's [App User Model ID](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391569(v=vs.85).aspx).
+    It has to be set, otherwise the other options will have no effect.
+  * `appIconPath` String (optional) - Window's [Relaunch Icon](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391573(v=vs.85).aspx).
+  * `appIconIndex` Integer (optional) - Index of the icon in `appIconPath`.
+    Ignored when `appIconPath` is not set. Default is `0`.
+  * `relaunchCommand` String (optional) - Window's [Relaunch Command](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391571(v=vs.85).aspx).
+  * `relaunchDisplayName` String (optional) - Window's [Relaunch Display Name](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391572(v=vs.85).aspx).
+
+Sets the properties for the window's taskbar button.
+
+**Note:** `relaunchCommand` and `relaunchDisplayName` must always be set
+together. If one of those properties is not set, then neither will be used.
+
 #### `win.showDefinitionForSelection()` _macOS_
 
 Same as `webContents.showDefinitionForSelection()`.
@@ -1192,6 +1251,12 @@ Returns `BrowserWindow` - The parent window.
 
 Returns `BrowserWindow[]` - All child windows.
 
+#### `win.setAutoHideCursor(autoHide)` _macOS_
+
+* `autoHide` Boolean
+
+Controls whether to hide cursor when typing.
+
 #### `win.setVibrancy(type)` _macOS_
 
 * `type` String - Can be `appearance-based`, `light`, `dark`, `titlebar`,
@@ -1201,7 +1266,8 @@ Returns `BrowserWindow[]` - All child windows.
 Adds a vibrancy effect to the browser window. Passing `null` or an empty string
 will remove the vibrancy effect on the window.
 
-[blink-feature-string]: https://cs.chromium.org/chromium/src/third_party/WebKit/Source/platform/RuntimeEnabledFeatures.in
+[blink-feature-string]: https://cs.chromium.org/chromium/src/third_party/WebKit/Source/platform/RuntimeEnabledFeatures.json5?l=62
 [quick-look]: https://en.wikipedia.org/wiki/Quick_Look
 [vibrancy-docs]: https://developer.apple.com/reference/appkit/nsvisualeffectview?language=objc
 [window-levels]: https://developer.apple.com/reference/appkit/nswindow/1664726-window_levels
+[chrome-content-scripts]: https://developer.chrome.com/extensions/content_scripts#execution-environment

--- a/test/fixtures/electron/docs/api/chrome-command-line-switches.md
+++ b/test/fixtures/electron/docs/api/chrome-command-line-switches.md
@@ -136,15 +136,6 @@ Sets the `version` of the pepper flash plugin.
 
 Enables net log events to be saved and writes them to `path`.
 
-## --ssl-version-fallback-min=`version`
-
-Sets the minimum SSL/TLS version (`tls1`, `tls1.1` or `tls1.2`) that TLS
-fallback will accept.
-
-## --cipher-suite-blacklist=`cipher_suites`
-
-Specifies comma-separated list of SSL cipher suites to disable.
-
 ## --disable-renderer-backgrounding
 
 Prevents Chromium from lowering the priority of invisible pages' renderer

--- a/test/fixtures/electron/docs/api/client-request.md
+++ b/test/fixtures/electron/docs/api/client-request.md
@@ -2,7 +2,7 @@
 
 > Make HTTP/HTTPS requests.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 `ClientRequest` implements the [Writable Stream](https://nodejs.org/api/stream.html#stream_writable_streams)
 interface and is therefore an [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter).

--- a/test/fixtures/electron/docs/api/clipboard.md
+++ b/test/fixtures/electron/docs/api/clipboard.md
@@ -2,7 +2,7 @@
 
 > Perform copy and paste operations on the system clipboard.
 
-Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)
 
 The following example shows how to write a string to the clipboard:
 
@@ -56,7 +56,7 @@ Writes `markup` to the clipboard.
 
 * `type` String (optional)
 
-Returns `NativeImage` - The content in the clipboard as a [NativeImage](native-image.md).
+Returns [`NativeImage`](native-image.md) - The image content in the clipboard.
 
 ### `clipboard.writeImage(image[, type])`
 

--- a/test/fixtures/electron/docs/api/content-tracing.md
+++ b/test/fixtures/electron/docs/api/content-tracing.md
@@ -3,28 +3,34 @@
 > Collect tracing data from Chromium's content module for finding performance
 bottlenecks and slow operations.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 This module does not include a web interface so you need to open
 `chrome://tracing/` in a Chrome browser and load the generated file to view the
 result.
 
+**Note:** You should not use this module until the `ready` event of the app
+module is emitted.
+
+
 ```javascript
-const {contentTracing} = require('electron')
+const {app, contentTracing} = require('electron')
 
-const options = {
-  categoryFilter: '*',
-  traceOptions: 'record-until-full,enable-sampling'
-}
+app.on('ready', () => {
+  const options = {
+    categoryFilter: '*',
+    traceOptions: 'record-until-full,enable-sampling'
+  }
 
-contentTracing.startRecording(options, () => {
-  console.log('Tracing started')
+  contentTracing.startRecording(options, () => {
+    console.log('Tracing started')
 
-  setTimeout(() => {
-    contentTracing.stopRecording('', (path) => {
-      console.log('Tracing data recorded to ' + path)
-    })
-  }, 5000)
+    setTimeout(() => {
+      contentTracing.stopRecording('', (path) => {
+        console.log('Tracing data recorded to ' + path)
+      })
+    }, 5000)
+  })
 })
 ```
 
@@ -76,7 +82,7 @@ list. Possible options are:
 * `enable-sampling`
 * `enable-systrace`
 
-The first 3 options are trace recoding modes and hence mutually exclusive.
+The first 3 options are trace recording modes and hence mutually exclusive.
 If more than one trace recording modes appear in the `traceOptions` string,
 the last one takes precedence. If none of the trace recording modes are
 specified, recording mode is `record-until-full`.
@@ -157,17 +163,3 @@ request the `callback` will be called with a file that contains the traced data.
 Get the maximum usage across processes of trace buffer as a percentage of the
 full state. When the TraceBufferUsage value is determined the `callback` is
 called.
-
-### `contentTracing.setWatchEvent(categoryName, eventName, callback)`
-
-* `categoryName` String
-* `eventName` String
-* `callback` Function
-
-`callback` will be called every time the given event occurs on any
-process.
-
-### `contentTracing.cancelWatchEvent()`
-
-Cancel the watch event. This may lead to a race condition with the watch event
-callback if tracing is enabled.

--- a/test/fixtures/electron/docs/api/cookies.md
+++ b/test/fixtures/electron/docs/api/cookies.md
@@ -2,7 +2,7 @@
 
 > Query and modify a session's cookies.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 Instances of the `Cookies` class are accessed by using `cookies` property of
 a `Session`.
@@ -79,15 +79,15 @@ with `callback(error, cookies)` on complete.
 
 * `details` Object
   * `url` String - The url to associate the cookie with.
-  * `name` String - The name of the cookie. Empty by default if omitted.
-  * `value` String - The value of the cookie. Empty by default if omitted.
-  * `domain` String - The domain of the cookie. Empty by default if omitted.
-  * `path` String - The path of the cookie. Empty by default if omitted.
-  * `secure` Boolean - Whether the cookie should be marked as Secure. Defaults to
+  * `name` String (optional) - The name of the cookie. Empty by default if omitted.
+  * `value` String (optional) - The value of the cookie. Empty by default if omitted.
+  * `domain` String (optional) - The domain of the cookie. Empty by default if omitted.
+  * `path` String (optional) - The path of the cookie. Empty by default if omitted.
+  * `secure` Boolean (optional) - Whether the cookie should be marked as Secure. Defaults to
     false.
-  * `httpOnly` Boolean - Whether the cookie should be marked as HTTP only.
+  * `httpOnly` Boolean (optional) - Whether the cookie should be marked as HTTP only.
     Defaults to false.
-  * `expirationDate` Double -	The expiration date of the cookie as the number of
+  * `expirationDate` Double (optional) - The expiration date of the cookie as the number of
     seconds since the UNIX epoch. If omitted then the cookie becomes a session
     cookie and will not be retained between sessions.
 * `callback` Function

--- a/test/fixtures/electron/docs/api/crash-reporter.md
+++ b/test/fixtures/electron/docs/api/crash-reporter.md
@@ -2,7 +2,7 @@
 
 > Submit crash reports to a remote server.
 
-Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)
 
 The following is an example of automatically submitting a crash report to a
 remote server:
@@ -14,7 +14,7 @@ crashReporter.start({
   productName: 'YourName',
   companyName: 'YourCompany',
   submitURL: 'https://your-domain.com/url-to-submit',
-  autoSubmit: true
+  uploadToServer: true
 })
 ```
 
@@ -32,7 +32,7 @@ API before starting the crash reporter.
 
 ## Methods
 
-The `crash-reporter` module has the following methods:
+The `crashReporter` module has the following methods:
 
 ### `crashReporter.start(options)`
 
@@ -40,21 +40,50 @@ The `crash-reporter` module has the following methods:
   * `companyName` String (optional)
   * `submitURL` String - URL that crash reports will be sent to as POST.
   * `productName` String (optional) - Defaults to `app.getName()`.
-  * `autoSubmit` Boolean (optional) - Send the crash report without user interaction.
+  * `uploadToServer` Boolean (optional) _macOS_ - Whether crash reports should be sent to the server
     Default is `true`.
   * `ignoreSystemCrashHandler` Boolean (optional) - Default is `false`.
   * `extra` Object (optional) - An object you can define that will be sent along with the
-    report. Only string properties are sent correctly, Nested objects are not
+    report. Only string properties are sent correctly. Nested objects are not
     supported.
 
-You are required to call this method before using other `crashReporter`
-APIs.
+You are required to call this method before using any other `crashReporter` APIs
+and in each process (main/renderer) from which you want to collect crash reports.
+You can pass different options to `crashReporter.start` when calling from different processes.
 
-**Note:** On macOS, Electron uses a new `crashpad` client, which is different
-from `breakpad` on Windows and Linux. To enable the crash collection feature,
-you are required to call the `crashReporter.start` API to initialize `crashpad`
-in the main process and in each renderer process from which you wish to collect
-crash reports.
+**Note** Child processes created via the `child_process` module will not have access to the Electron modules.
+Therefore, to collect crash reports from them, use `process.crashReporter.start` instead. Pass the same options as above
+along with an additional one called `crashesDirectory` that should point to a directory to store the crash
+reports temporarily. You can test this out by calling `process.crash()` to crash the child process.
+
+**Note:** To collect crash reports from child process in Windows, you need to add this extra code as well.
+This will start the process that will monitor and send the crash reports. Replace `submitURL`, `productName`
+and `crashesDirectory` with appropriate values.
+
+**Note:** If you need send additional/updated `extra` parameters after your
+first call `start` you can call `setExtraParameter` on macOS or call `start`
+again with the new/updated `extra` parameters on Linux and Windows.
+
+```js
+ const args = [
+   `--reporter-url=${submitURL}`,
+   `--application-name=${productName}`,
+   `--crashes-directory=${crashesDirectory}`
+ ]
+ const env = {
+   ELECTRON_INTERNAL_CRASH_SERVICE: 1
+ }
+ spawn(process.execPath, args, {
+   env: env,
+   detached: true
+ })
+```
+
+**Note:** On macOS, Electron uses a new `crashpad` client for crash collection and reporting.
+If you want to enable crash reporting, initializing `crashpad` from the main process using `crashReporter.start` is required
+regardless of which process you want to collect crashes from. Once initialized this way, the crashpad handler collects
+crashes from all processes. You still have to call `crashReporter.start` from the renderer or child process, otherwise crashes from
+them will get reported without `companyName`, `productName` or any of the `extra` information.
 
 ### `crashReporter.getLastCrashReport()`
 
@@ -70,7 +99,35 @@ Returns [`CrashReport[]`](structures/crash-report.md):
 Returns all uploaded crash reports. Each report contains the date and uploaded
 ID.
 
-## crash-reporter Payload
+### `crashReporter.getUploadToServer()` _macOS_
+
+Returns `Boolean` - Whether reports should be submitted to the server.  Set through
+the `start` method or `setUploadToServer`.
+
+**Note:** This API can only be called from the main process.
+
+### `crashReporter.setUploadToServer(uploadToServer)` _macOS_
+
+* `uploadToServer` Boolean _macOS_ - Whether reports should be submitted to the server
+
+This would normally be controlled by user preferences. This has no effect if
+called before `start` is called.
+
+**Note:** This API can only be called from the main process.
+
+### `crashReporter.setExtraParameter(key, value)` _macOS_
+
+* `key` String - Parameter key.
+* `value` String - Parameter value. Specifying `null` or `undefined` will
+  remove the key from the extra parameters.
+
+Set an extra parameter to set be sent with the crash report. The values
+specified here will be sent in addition to any values set via the `extra` option
+when `start` was called. This API is only available on macOS, if you need to
+add/update extra parameters on Linux and Windows after your first call to
+`start` you can call `start` again with the updated `extra` options.
+
+## Crash Report Payload
 
 The crash reporter will send the following data to the `submitURL` as
 a `multipart/form-data` `POST`:

--- a/test/fixtures/electron/docs/api/debugger.md
+++ b/test/fixtures/electron/docs/api/debugger.md
@@ -2,7 +2,7 @@
 
 > An alternate transport for Chrome's remote debugging protocol.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 Chrome Developer Tools has a [special binding][rdp] available at JavaScript
 runtime that allows interacting with pages and instrumenting them.

--- a/test/fixtures/electron/docs/api/desktop-capturer.md
+++ b/test/fixtures/electron/docs/api/desktop-capturer.md
@@ -3,7 +3,7 @@
 > Access information about media sources that can be used to capture audio and
 > video from the desktop using the [`navigator.webkitGetUserMedia`] API.
 
-Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+Process: [Renderer](../glossary.md#renderer-process)
 
 The following example shows how to capture video from a desktop window whose
 title is `Electron`:

--- a/test/fixtures/electron/docs/api/dialog.md
+++ b/test/fixtures/electron/docs/api/dialog.md
@@ -38,14 +38,14 @@ The `dialog` module has the following methods:
     * `openDirectory` - Allow directories to be selected.
     * `multiSelections` - Allow multiple paths to be selected.
     * `showHiddenFiles` - Show hidden files in dialog.
-    * `createDirectory` _macOS_ - Allow creating new directories from dialog.
-    * `promptToCreate` _Windows_ - Prompt for creation if the file path entered
+    * `createDirectory` - Allow creating new directories from dialog. _macOS_
+    * `promptToCreate` - Prompt for creation if the file path entered
       in the dialog does not exist. This does not actually create the file at
       the path but allows non-existent paths to be returned that should be
-      created by the application.
-    * `noResolveAliases` _macOS_ - Disable the automatic alias (symlink) path
+      created by the application. _Windows_
+    * `noResolveAliases` - Disable the automatic alias (symlink) path
       resolution.  Selected aliases will now return the alias path instead of
-      their target path.
+      their target path. _macOS_
   * `normalizeAccessKeys` Boolean (optional) - Normalize the keyboard access keys
     across platforms. Default is `false`. Enabling this assumes `&` is used in
     the button labels for the placement of the keyboard shortcut access key

--- a/test/fixtures/electron/docs/api/dialog.md
+++ b/test/fixtures/electron/docs/api/dialog.md
@@ -2,7 +2,7 @@
 
 > Display native system dialogs for opening and saving files, alerting, etc.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 An example of showing a dialog to select multiple files and directories:
 
@@ -31,15 +31,38 @@ The `dialog` module has the following methods:
   * `defaultPath` String (optional)
   * `buttonLabel` String (optional) - Custom label for the confirmation button, when
     left empty the default label will be used.
-  * `filters` [FileFilter[]](structrs/file-filter.md) (optional)
-  * `properties` String[] (optional) - Contains which features the dialog should use, can
-    contain `openFile`, `openDirectory`, `multiSelections`, `createDirectory`
-    and `showHiddenFiles`.
+  * `filters` [FileFilter[]](structures/file-filter.md) (optional)
+  * `properties` String[] (optional) - Contains which features the dialog should
+    use. The following values are supported:
+    * `openFile` - Allow files to be selected.
+    * `openDirectory` - Allow directories to be selected.
+    * `multiSelections` - Allow multiple paths to be selected.
+    * `showHiddenFiles` - Show hidden files in dialog.
+    * `createDirectory` _macOS_ - Allow creating new directories from dialog.
+    * `promptToCreate` _Windows_ - Prompt for creation if the file path entered
+      in the dialog does not exist. This does not actually create the file at
+      the path but allows non-existent paths to be returned that should be
+      created by the application.
+    * `noResolveAliases` _macOS_ - Disable the automatic alias (symlink) path
+      resolution.  Selected aliases will now return the alias path instead of
+      their target path.
+  * `normalizeAccessKeys` Boolean (optional) - Normalize the keyboard access keys
+    across platforms. Default is `false`. Enabling this assumes `&` is used in
+    the button labels for the placement of the keyboard shortcut access key
+    and labels will be converted so they work correctly on each platform, `&`
+    characters are removed on macOS, converted to `_` on Linux, and left
+    untouched on Windows. For example, a button label of `Vie&w` will be
+    converted to `Vie_w` on Linux and `View` on macOS and can be selected
+    via `Alt-W` on Windows and Linux.
+    * `message` String (optional) _macOS_ - Message to display above input
+      boxes.
 * `callback` Function (optional)
   * `filePaths` String[] - An array of file paths chosen by the user
 
 Returns `String[]`, an array of file paths chosen by the user,
 if the callback is provided it returns `undefined`.
+
+The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
 
 The `filters` specifies an array of file types that can be displayed or
 selected when you want to limit the user to a specific type. For example:
@@ -75,12 +98,19 @@ shown.
   * `defaultPath` String (optional)
   * `buttonLabel` String (optional) - Custom label for the confirmation button, when
     left empty the default label will be used.
-  * `filters` [FileFilter[]](structrs/file-filter.md) (optional)
+  * `filters` [FileFilter[]](structures/file-filter.md) (optional)
+  * `message` String (optional) _macOS_ - Message to display above text fields.
+  * `nameFieldLabel` String (optional) _macOS_ - Custom label for the text
+    displayed in front of the filename text field.
+  * `showsTagField` Boolean (optional) _macOS_ - Show the tags input box,
+    defaults to `true`.
 * `callback` Function (optional)
   * `filename` String
 
 Returns `String`, the path of the file chosen by the user,
 if a callback is provided it returns `undefined`.
+
+The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
 
 The `filters` specifies an array of file types that can be displayed, see
 `dialog.showOpenDialog` for an example.
@@ -102,12 +132,16 @@ will be passed via `callback(filename)`
   * `title` String (optional) - Title of the message box, some platforms will not show it.
   * `message` String - Content of the message box.
   * `detail` String (optional) - Extra information of the message.
+  * `checkboxLabel` String (optional) - If provided, the message box will
+    include a checkbox with the given label. The checkbox state can be
+    inspected only when using `callback`.
+  * `checkboxChecked` Boolean (optional) - Initial checked state of the
+    checkbox. `false` by default.
   * `icon` [NativeImage](native-image.md) (optional)
-  * `cancelId` Integer (optional) - The value will be returned when user cancels the dialog
-    instead of clicking the buttons of the dialog. By default it is the index
-    of the buttons that have "cancel" or "no" as label, or 0 if there is no such
-    buttons. On macOS and Windows the index of "Cancel" button will always be
-    used as `cancelId`, not matter whether it is already specified.
+  * `cancelId` Integer (optional) - The index of the button to be used to cancel the dialog, via
+    the `Esc` key. By default this is assigned to the first button with "cancel" or "no" as the
+    label. If no such labeled buttons exist and this option is not set, `0` will be used as the
+    return value or callback response. This option is ignored on Windows.
   * `noLink` Boolean (optional) - On Windows Electron will try to figure out which one of
     the `buttons` are common buttons (like "Cancel" or "Yes"), and show the
     others as command links in the dialog. This can make the dialog appear in
@@ -115,12 +149,16 @@ will be passed via `callback(filename)`
     set `noLink` to `true`.
 * `callback` Function (optional)
   * `response` Number - The index of the button that was clicked
+  * `checkboxChecked` Boolean - The checked state of the checkbox if
+    `checkboxLabel` was set. Otherwise `false`.
 
 Returns `Integer`, the index of the clicked button, if a callback is provided
 it returns undefined.
 
 Shows a message box, it will block the process until the message box is closed.
 It returns the index of the clicked button.
+
+The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
 
 If a `callback` is passed, the API call will be asynchronous and the result
 will be passed via `callback(response)`.

--- a/test/fixtures/electron/docs/api/download-item.md
+++ b/test/fixtures/electron/docs/api/download-item.md
@@ -2,7 +2,7 @@
 
 > Control file downloads from remote sources.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 `DownloadItem` is an `EventEmitter` that represents a download item in Electron.
 It is used in `will-download` event of `Session` class, and allows users to
@@ -146,3 +146,23 @@ header.
 #### `downloadItem.getState()`
 
 Returns `String` - The current state.  Can be `progressing`, `completed`, `cancelled` or `interrupted`.
+
+**Note:** The following methods are useful specifically to resume a
+`cancelled` item when session is restarted.
+
+#### `downloadItem.getURLChain()`
+
+Returns `String[]` - The complete url chain of the item including any redirects.
+
+#### `downloadItem.getLastModifiedTime()`
+
+Returns `String` - Last-Modified header value.
+
+#### `downloadItem.getETag()`
+
+Returns `String` - ETag header value.
+
+#### `downloadItem.getStartTime()`
+
+Returns `Double` - Number of seconds since the UNIX epoch when the download was
+started.

--- a/test/fixtures/electron/docs/api/environment-variables.md
+++ b/test/fixtures/electron/docs/api/environment-variables.md
@@ -46,14 +46,23 @@ geocoding requests. To enable geocoding requests, visit [this page](https://cons
 Disables ASAR support. This variable is only supported in forked child processes
 and spawned child processes that set `ELECTRON_RUN_AS_NODE`.
 
+### `ELECTRON_RUN_AS_NODE`
+
+Starts the process as a normal Node.js process.
+
+### `ELECTRON_NO_ATTACH_CONSOLE` _Windows_
+
+Don't attach to the current console session.
+
+### `ELECTRON_FORCE_WINDOW_MENU_BAR` _Linux_
+
+Don't use the global menu bar on Linux.
+
 ## Development Variables
 
 The following environment variables are intended primarily for development and
 debugging purposes.
 
-### `ELECTRON_RUN_AS_NODE`
-
-Starts the process as a normal Node.js process.
 
 ### `ELECTRON_ENABLE_LOGGING`
 
@@ -76,11 +85,3 @@ This environment variable will not work if the `crashReporter` is started.
 Shows the Windows's crash dialog when Electron crashes.
 
 This environment variable will not work if the `crashReporter` is started.
-
-### `ELECTRON_NO_ATTACH_CONSOLE` _Windows_
-
-Don't attach to the current console session.
-
-### `ELECTRON_FORCE_WINDOW_MENU_BAR` _Linux_
-
-Don't use the global menu bar on Linux.

--- a/test/fixtures/electron/docs/api/global-shortcut.md
+++ b/test/fixtures/electron/docs/api/global-shortcut.md
@@ -2,7 +2,7 @@
 
 > Detect keyboard events when the application does not have keyboard focus.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 The `globalShortcut` module can register/unregister a global keyboard shortcut
 with the operating system so that you can customize the operations for various

--- a/test/fixtures/electron/docs/api/incoming-message.md
+++ b/test/fixtures/electron/docs/api/incoming-message.md
@@ -2,7 +2,7 @@
 
 > Handle responses to HTTP/HTTPS requests.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 `IncomingMessage` implements the [Readable Stream](https://nodejs.org/api/stream.html#stream_readable_streams)
 interface and is therefore an [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter).
@@ -64,3 +64,11 @@ A String indicating the HTTP protocol version number. Typical values are '1.0'
 or '1.1'. Additionally `httpVersionMajor` and `httpVersionMinor` are two
 Integer-valued readable properties that return respectively the HTTP major and
 minor version numbers.
+
+#### `response.httpVersionMajor`
+
+An Integer indicating the HTTP protocol major version number.
+
+#### `response.httpVersionMinor`
+
+An Integer indicating the HTTP protocol minor version number.

--- a/test/fixtures/electron/docs/api/ipc-main.md
+++ b/test/fixtures/electron/docs/api/ipc-main.md
@@ -2,7 +2,7 @@
 
 > Communicate asynchronously from the main process to renderer processes.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 The `ipcMain` module is an instance of the
 [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) class. When used in the main

--- a/test/fixtures/electron/docs/api/ipc-renderer.md
+++ b/test/fixtures/electron/docs/api/ipc-renderer.md
@@ -2,7 +2,7 @@
 
 > Communicate asynchronously from a renderer process to the main process.
 
-Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+Process: [Renderer](../glossary.md#renderer-process)
 
 The `ipcRenderer` module is an instance of the
 [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) class. It provides a few

--- a/test/fixtures/electron/docs/api/locales.md
+++ b/test/fixtures/electron/docs/api/locales.md
@@ -8,13 +8,13 @@ values are listed below:
 | Language Code | Language Name |
 |---------------|---------------|
 | af | Afrikaans |
+| an | Aragonese |
 | ar-AE | Arabic (U.A.E.) |
 | ar-IQ | Arabic (Iraq) |
 | ar | Arabic (Standard) |
 | ar-BH | Arabic (Bahrain) |
 | ar-DZ | Arabic (Algeria) |
 | ar-EG | Arabic (Egypt) |
-| ar | Aragonese |
 | ar-JO | Arabic (Jordan) |
 | ar-KW | Arabic (Kuwait) |
 | ar-LB | Arabic (Lebanon) |

--- a/test/fixtures/electron/docs/api/menu-item.md
+++ b/test/fixtures/electron/docs/api/menu-item.md
@@ -2,38 +2,38 @@
 
 > Add items to native application menus and context menus.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 See [`Menu`](menu.md) for examples.
 
 ### `new MenuItem(options)`
 
 * `options` Object
-  * `click` Function - (optional) Will be called with
+  * `click` Function (optional) - Will be called with
     `click(menuItem, browserWindow, event)` when the menu item is clicked.
     * `menuItem` MenuItem
     * `browserWindow` BrowserWindow
     * `event` Event
-  * `role` String - (optional) Define the action of the menu item, when specified the
+  * `role` String (optional) - Define the action of the menu item, when specified the
     `click` property will be ignored.
-  * `type` String - (optional) Can be `normal`, `separator`, `submenu`, `checkbox` or
+  * `type` String (optional) - Can be `normal`, `separator`, `submenu`, `checkbox` or
     `radio`.
   * `label` String - (optional)
   * `sublabel` String - (optional)
-  * `accelerator` [Accelerator](accelerator.md) - (optional)
-  * `icon` ([NativeImage](native-image.md) | String) - (optional)
-  * `enabled` Boolean - (optional) If false, the menu item will be greyed out and
+  * `accelerator` [Accelerator](accelerator.md) (optional)
+  * `icon` ([NativeImage](native-image.md) | String) (optional)
+  * `enabled` Boolean (optional) - If false, the menu item will be greyed out and
     unclickable.
-  * `visible` Boolean - (optional) If false, the menu item will be entirely hidden.
-  * `checked` Boolean - (optional) Should only be specified for `checkbox` or `radio` type
+  * `visible` Boolean (optional) - If false, the menu item will be entirely hidden.
+  * `checked` Boolean (optional) - Should only be specified for `checkbox` or `radio` type
     menu items.
-  * `submenu` MenuItemConstructorOptions[] - (optional) Should be specified for `submenu` type menu items. If
+  * `submenu` (MenuItemConstructorOptions[] | Menu) (optional) - Should be specified for `submenu` type menu items. If
     `submenu` is specified, the `type: 'submenu'` can be omitted. If the value
     is not a `Menu` then it will be automatically converted to one using
     `Menu.buildFromTemplate`.
-  * `id` String - (optional) Unique within a single menu. If defined then it can be used
+  * `id` String (optional) - Unique within a single menu. If defined then it can be used
     as a reference to this item by the position attribute.
-  * `position` String - (optional) This field allows fine-grained definition of the
+  * `position` String (optional) - This field allows fine-grained definition of the
     specific location within a given menu.
 
 It is best to specify `role` for any menu item that matches a standard role,
@@ -56,6 +56,9 @@ The `role` property can have following values:
 * `minimize` - Minimize current window
 * `close` - Close current window
 * `quit`- Quit the application
+* `reload` - Reload the current window
+* `forcereload` - Reload the current window ignoring the cache.
+* `toggledevtools` - Toggle developer tools in the current window
 * `togglefullscreen`- Toggle full screen mode on the current window
 * `resetzoom` - Reset the focused page's zoom level to the original size
 * `zoomin` - Zoom in the focused page by 10%
@@ -104,3 +107,11 @@ A `radio` menu item will turn on its `checked` property when clicked, and
 will turn off that property for all adjacent items in the same menu.
 
 You can add a `click` function for additional behavior.
+
+#### `menuItem.label`
+
+A String representing the menu items visible label
+
+#### `menuItem.click`
+
+A Function that is fired when the MenuItem recieves a click event

--- a/test/fixtures/electron/docs/api/menu.md
+++ b/test/fixtures/electron/docs/api/menu.md
@@ -2,7 +2,7 @@
 
 > Create native application menus and context menus.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 ### `new Menu()`
 
@@ -52,16 +52,27 @@ will become properties of the constructed menu items.
 
 The `menu` object has the following instance methods:
 
-#### `menu.popup([browserWindow, x, y, positioningItem])`
+#### `menu.popup([browserWindow, options])`
 
-* `browserWindow` BrowserWindow (optional) - Default is `BrowserWindow.getFocusedWindow()`.
-* `x` Number (optional) - Default is the current mouse cursor position.
-* `y` Number (**required** if `x` is used) - Default is the current mouse cursor position.
-* `positioningItem` Number (optional) _macOS_ - The index of the menu item to
-  be positioned under the mouse cursor at the specified coordinates. Default is
-  -1.
+* `browserWindow` BrowserWindow (optional) - Default is the focused window.
+* `options` Object (optional)
+  * `x` Number (optional) - Default is the current mouse cursor position.
+  * `y` Number (**required** if `x` is used) - Default is the current mouse
+    cursor position.
+  * `async` Boolean (optional) - Set to `true` to have this method return
+    immediately called, `false` to return after the menu has been selected
+    or closed. Defaults to `false`.
+  * `positioningItem` Number (optional) _macOS_ - The index of the menu item to
+    be positioned under the mouse cursor at the specified coordinates. Default
+    is -1.
 
 Pops up this menu as a context menu in the `browserWindow`.
+
+#### `menu.closePopup([browserWindow])`
+
+* `browserWindow` BrowserWindow (optional) - Default is the focused window.
+
+Closes the context menu in the `browserWindow`.
 
 #### `menu.append(menuItem)`
 
@@ -137,18 +148,13 @@ const template = [
     label: 'View',
     submenu: [
       {
-        label: 'Reload',
-        accelerator: 'CmdOrCtrl+R',
-        click (item, focusedWindow) {
-          if (focusedWindow) focusedWindow.reload()
-        }
+        role: 'reload'
       },
       {
-        label: 'Toggle Developer Tools',
-        accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
-        click (item, focusedWindow) {
-          if (focusedWindow) focusedWindow.webContents.toggleDevTools()
-        }
+        role: 'forcereload'
+      },
+      {
+        role: 'toggledevtools'
       },
       {
         type: 'separator'

--- a/test/fixtures/electron/docs/api/native-image.md
+++ b/test/fixtures/electron/docs/api/native-image.md
@@ -2,7 +2,7 @@
 
 > Create tray, dock, and application icons using PNG or JPG files.
 
-Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)
 
 In Electron, for the APIs that take images, you can pass either file paths or
 `NativeImage` instances. An empty image will be used when `null` is passed.
@@ -137,15 +137,17 @@ let image = nativeImage.createFromPath('/Users/somebody/images/icon.png')
 console.log(image)
 ```
 
-### `nativeImage.createFromBuffer(buffer[, scaleFactor])`
+### `nativeImage.createFromBuffer(buffer[, options])`
 
 * `buffer` [Buffer][buffer]
-* `scaleFactor` Double (optional)
+* `options` Object (optional)
+  * `width` Integer (optional) - Required for bitmap buffers.
+  * `height` Integer (optional) - Required for bitmap buffers.
+  * `scaleFactor` Double (optional) - Defaults to 1.0.
 
 Returns `NativeImage`
 
-Creates a new `NativeImage` instance from `buffer`. The default `scaleFactor` is
-1.0.
+Creates a new `NativeImage` instance from `buffer`.
 
 ### `nativeImage.createFromDataURL(dataURL)`
 
@@ -157,7 +159,7 @@ Creates a new `NativeImage` instance from `dataURL`.
 
 > Natively wrap images such as tray, dock, and application icons.
 
-Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)
 
 ### Instance Methods
 

--- a/test/fixtures/electron/docs/api/net.md
+++ b/test/fixtures/electron/docs/api/net.md
@@ -2,7 +2,7 @@
 
 > Issue HTTP/HTTPS requests using Chromium's native networking library
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 The `net` module is a client-side API for issuing HTTP(S) requests. It is
 similar to the [HTTP](https://nodejs.org/api/http.html) and
@@ -63,7 +63,7 @@ The `net` module has the following methods:
 
 * `options` (Object | String) - The `ClientRequest` constructor options.
 
-Returns `ClientRequest`
+Returns [`ClientRequest`](./client-request.md)
 
 Creates a [`ClientRequest`](./client-request.md) instance using the provided
 `options` which are directly forwarded to the `ClientRequest` constructor.

--- a/test/fixtures/electron/docs/api/power-monitor.md
+++ b/test/fixtures/electron/docs/api/power-monitor.md
@@ -2,7 +2,7 @@
 
 > Monitor power state changes.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 You cannot require or use this module until the `ready` event of the `app`
 module is emitted.

--- a/test/fixtures/electron/docs/api/power-save-blocker.md
+++ b/test/fixtures/electron/docs/api/power-save-blocker.md
@@ -2,7 +2,7 @@
 
 > Block the system from entering low-power (sleep) mode.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 For example:
 

--- a/test/fixtures/electron/docs/api/process.md
+++ b/test/fixtures/electron/docs/api/process.md
@@ -2,9 +2,11 @@
 
 > Extensions to process object.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)
 
-The `process` object is extended in Electron with following APIs:
+Electron's `process` object is extended from the
+[Node.js `process` object](https://nodejs.org/api/process.html).
+It adds the following events, properties, and methods:
 
 ## Events
 

--- a/test/fixtures/electron/docs/api/protocol.md
+++ b/test/fixtures/electron/docs/api/protocol.md
@@ -2,7 +2,7 @@
 
 > Register a custom protocol and intercept existing protocol requests.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 An example of implementing a protocol that has the same effect as the
 `file://` protocol:
@@ -28,9 +28,12 @@ of the `app` module gets emitted.
 
 The `protocol` module has the following methods:
 
-### `protocol.registerStandardSchemes(schemes)`
+### `protocol.registerStandardSchemes(schemes[, options])`
 
 * `schemes` String[] - Custom schemes to be registered as standard schemes.
+* `options` Object (optional)
+  * `secure` Boolean (optional) - `true` to register the scheme as secure.
+    Default `false`.
 
 A standard scheme adheres to what RFC 3986 calls [generic URI
 syntax](https://tools.ietf.org/html/rfc3986#section-3). For example `http` and
@@ -118,7 +121,7 @@ treated as a standard scheme.
     * `method` String
     * `uploadData` [UploadData[]](structures/upload-data.md)
   * `callback` Function
-    * `buffer` Buffer (optional)
+    * `buffer` (Buffer | [MimeTypedBuffer](structures/mime-typed-buffer.md)) (optional)
 * `completion` Function (optional)
   * `error` Error
 

--- a/test/fixtures/electron/docs/api/remote.md
+++ b/test/fixtures/electron/docs/api/remote.md
@@ -2,7 +2,7 @@
 
 > Use main process modules from the renderer process.
 
-Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+Process: [Renderer](../glossary.md#renderer-process)
 
 The `remote` module provides a simple way to do inter-process communication
 (IPC) between the renderer process (web page) and the main process.
@@ -144,12 +144,12 @@ Returns `any` - The object returned by `require(module)` in the main process.
 
 ### `remote.getCurrentWindow()`
 
-Returns `BrowserWindow` - The [`BrowserWindow`](browser-window.md) object to which this web page
+Returns [`BrowserWindow`](browser-window.md) - The window to which this web page
 belongs.
 
 ### `remote.getCurrentWebContents()`
 
-Returns `WebContents` - The [`WebContents`](web-contents.md) object of this web page.
+Returns [`WebContents`](web-contents.md) - The web contents of this web page.
 
 ### `remote.getGlobal(name)`
 

--- a/test/fixtures/electron/docs/api/screen.md
+++ b/test/fixtures/electron/docs/api/screen.md
@@ -2,7 +2,7 @@
 
 > Retrieve information about screen size, displays, cursor position, etc.
 
-Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)
 
 You cannot require or use this module until the `ready` event of the `app`
 module is emitted.
@@ -100,11 +100,11 @@ The current absolute position of the mouse pointer.
 
 ### `screen.getPrimaryDisplay()`
 
-Returns `Display` - The primary display.
+Returns [`Display`](structures/display.md) - The primary display.
 
 ### `screen.getAllDisplays()`
 
-Returns `Display[]` - An array of displays that are currently available.
+Returns [`Display[]`](structures/display.md) - An array of displays that are currently available.
 
 ### `screen.getDisplayNearestPoint(point)`
 
@@ -112,10 +112,11 @@ Returns `Display[]` - An array of displays that are currently available.
   * `x` Integer
   * `y` Integer
 
-Returns `Display` - The display nearest the specified point.
+Returns [`Display`](structures/display.md) - The display nearest the specified point.
 
 ### `screen.getDisplayMatching(rect)`
 
 * `rect` [Rectangle](structures/rectangle.md)
 
-Returns `Display` - The display that most closely intersects the provided bounds.
+Returns [`Display`](structures/display.md) - The display that most closely
+intersects the provided bounds.

--- a/test/fixtures/electron/docs/api/session.md
+++ b/test/fixtures/electron/docs/api/session.md
@@ -2,7 +2,7 @@
 
 > Manage browser sessions, cookies, cache, proxy settings, etc.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 The `session` module can be used to create new `Session` objects.
 
@@ -30,7 +30,7 @@ The `session` module has the following methods:
   * `cache` Boolean - Whether to enable cache.
 
 Returns `Session` - A session instance from `partition` string. When there is an existing
-`Session` with the same `partition`, it will be returned; othewise a new
+`Session` with the same `partition`, it will be returned; otherwise a new
 `Session` instance will be created with `options`.
 
 If `partition` starts with `persist:`, the page will use a persistent session
@@ -54,7 +54,7 @@ A `Session` object, the default session object of the app.
 
 > Get and set properties of a session.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 You can create a `Session` object in the `session` module:
 
@@ -98,7 +98,7 @@ The following methods are available on instances of `Session`:
 * `callback` Function
   * `size` Integer - Cache size used in bytes.
 
-Returns the session's current cache size.
+Callback is invoked with the session's current cache size.
 
 #### `ses.clearCache(callback)`
 
@@ -112,7 +112,7 @@ Clears the session’s HTTP cache.
   * `origin` String - Should follow `window.location.origin`’s representation
     `scheme://host:port`.
   * `storages` String[] - The types of storages to clear, can contain:
-    `appcache`, `cookies`, `filesystem`, `indexdb`, `local storage`,
+    `appcache`, `cookies`, `filesystem`, `indexdb`, `localstorage`,
     `shadercache`, `websql`, `serviceworkers`
   * `quotas` String[] - The types of quotas to clear, can contain:
     `temporary`, `persistent`, `syncable`.
@@ -200,7 +200,7 @@ The `proxyBypassRules` is a comma separated list of rules described below:
    Match local addresses. The meaning of `<local>` is whether the
    host matches one of: "127.0.0.1", "::1", "localhost".
 
-### `ses.resolveProxy(url, callback)`
+#### `ses.resolveProxy(url, callback)`
 
 * `url` URL
 * `callback` Function
@@ -250,15 +250,22 @@ the original network configuration.
 #### `ses.setCertificateVerifyProc(proc)`
 
 * `proc` Function
-  * `hostname` String
-  * `certificate` [Certificate](structures/certificate.md)
+  * `request` Object
+    * `hostname` String
+    * `certificate` [Certificate](structures/certificate.md)
+    * `error` String - Verification result from chromium.
   * `callback` Function
-    * `isTrusted` Boolean - Determines if the certificate should be trusted
+    * `verificationResult` Integer - Value can be one of certificate error codes
+    from [here](https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h).
+    Apart from the certificate error codes, the following special codes can be used.
+      * `0` - Indicates success and disables Certificate Transperancy verification.
+      * `-2` - Indicates failure.
+      * `-3` - Uses the verification result from chromium.
 
 Sets the certificate verify proc for `session`, the `proc` will be called with
-`proc(hostname, certificate, callback)` whenever a server certificate
-verification is requested. Calling `callback(true)` accepts the certificate,
-calling `callback(false)` rejects it.
+`proc(request, callback)` whenever a server certificate
+verification is requested. Calling `callback(0)` accepts the certificate,
+calling `callback(-2)` rejects it.
 
 Calling `setCertificateVerifyProc(null)` will revert back to default certificate
 verify proc.
@@ -267,8 +274,13 @@ verify proc.
 const {BrowserWindow} = require('electron')
 let win = new BrowserWindow()
 
-win.webContents.session.setCertificateVerifyProc((hostname, cert, callback) => {
-  callback(hostname === 'github.com')
+win.webContents.session.setCertificateVerifyProc((request, callback) => {
+  const {hostname} = request
+  if (hostname === 'github.com') {
+    callback(0)
+  } else {
+    callback(-2)
+  }
 })
 ```
 
@@ -343,6 +355,32 @@ Returns `String` - The user agent for this session.
   * `result` Buffer - Blob data.
 
 Returns `Blob` - The blob data associated with the `identifier`.
+
+#### `ses.createInterruptedDownload(options)`
+
+* `options` Object
+  * `path` String - Absolute path of the download.
+  * `urlChain` String[] - Complete URL chain for the download.
+  * `mimeType` String (optional)
+  * `offset` Integer - Start range for the download.
+  * `length` Integer - Total length of the download.
+  * `lastModified` String - Last-Modified header value.
+  * `eTag` String - ETag header value.
+  * `startTime` Double (optional) - Time when download was started in
+    number of seconds since UNIX epoch.
+
+Allows resuming `cancelled` or `interrupted` downloads from previous `Session`.
+The API will generate a [DownloadItem](download-item.md) that can be accessed with the [will-download](#event-will-download)
+event. The [DownloadItem](download-item.md) will not have any `WebContents` associated with it and
+the initial state will be `interrupted`. The download will start only when the
+`resume` API is called on the [DownloadItem](download-item.md).
+
+#### `ses.clearAuthCache(options[, callback])`
+
+* `options` ([RemovePassword](structures/remove-password.md) | [RemoveClientCertificate](structures/remove-client-certificate.md))
+* `callback` Function (optional) - Called when operation is done
+
+Clears the session’s HTTP authentication cache.
 
 ### Instance Properties
 

--- a/test/fixtures/electron/docs/api/shell.md
+++ b/test/fixtures/electron/docs/api/shell.md
@@ -2,7 +2,7 @@
 
 > Manage files and URLs using their default applications.
 
-Process: [Main](../tutorial/quick-start.md#main-process), [Renderer](../tutorial/quick-start.md#renderer-process)
+Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)
 
 The `shell` module provides functions related to desktop integration.
 
@@ -34,14 +34,17 @@ Returns `Boolean` - Whether the item was successfully opened.
 
 Open the given file in the desktop's default manner.
 
-### `shell.openExternal(url[, options])`
+### `shell.openExternal(url[, options, callback])`
 
 * `url` String
 * `options` Object (optional) _macOS_
   * `activate` Boolean - `true` to bring the opened application to the
     foreground. The default is `true`.
+* `callback` Function (optional) - If specified will perform the open asynchronously. _macOS_
+  * `error` Error
 
 Returns `Boolean` - Whether an application was available to open the URL.
+If callback is specified, always returns true.
 
 Open the given external protocol URL in the desktop's default manner. (For
 example, mailto: URLs in the user's default mail agent).

--- a/test/fixtures/electron/docs/api/structures/certificate-principal.md
+++ b/test/fixtures/electron/docs/api/structures/certificate-principal.md
@@ -1,0 +1,8 @@
+# CertificatePrincipal Object
+
+* `commonName` String - Common Name
+* `organizations` String[] - Organization names
+* `organizationUnits` String[] - Organization Unit names
+* `locality` String - Locality
+* `state` String - State or province
+* `country` String - Country or region

--- a/test/fixtures/electron/docs/api/structures/certificate.md
+++ b/test/fixtures/electron/docs/api/structures/certificate.md
@@ -1,7 +1,10 @@
 # Certificate Object
 
 * `data` String - PEM encoded data
+* `issuer` [CertificatePrincipal](certificate-principal.md) - Issuer principal
 * `issuerName` String - Issuer's Common Name
+* `issuerCert` Certificate - Issuer certificate (if not self-signed)
+* `subject` [CertificatePrincipal](certificate-principal.md) - Subject principal
 * `subjectName` String - Subject's Common Name
 * `serialNumber` String - Hex value represented string
 * `validStart` Number - Start date of the certificate being valid in seconds

--- a/test/fixtures/electron/docs/api/structures/cookie.md
+++ b/test/fixtures/electron/docs/api/structures/cookie.md
@@ -2,12 +2,12 @@
 
 * `name` String - The name of the cookie.
 * `value` String - The value of the cookie.
-* `domain` String - The domain of the cookie.
-* `hostOnly` String - Whether the cookie is a host-only cookie.
-* `path` String - The path of the cookie.
-* `secure` Boolean - Whether the cookie is marked as secure.
-* `httpOnly` Boolean - Whether the cookie is marked as HTTP only.
-* `session` Boolean - Whether the cookie is a session cookie or a persistent
+* `domain` String (optional) - The domain of the cookie.
+* `hostOnly` Boolean (optional) - Whether the cookie is a host-only cookie.
+* `path` String (optional) - The path of the cookie.
+* `secure` Boolean (optional) - Whether the cookie is marked as secure.
+* `httpOnly` Boolean (optional) - Whether the cookie is marked as HTTP only.
+* `session` Boolean (optional) - Whether the cookie is a session cookie or a persistent
   cookie with an expiration date.
 * `expirationDate` Double (optional) - The expiration date of the cookie as
   the number of seconds since the UNIX epoch. Not provided for session

--- a/test/fixtures/electron/docs/api/structures/jump-list-category.md
+++ b/test/fixtures/electron/docs/api/structures/jump-list-category.md
@@ -1,6 +1,6 @@
 # JumpListCategory Object
 
-* `type` String - One of the following:
+* `type` String (optional) - One of the following:
   * `tasks` - Items in this category will be placed into the standard `Tasks`
     category. There can be only one such category, and it will always be
     displayed at the bottom of the Jump List.
@@ -10,9 +10,9 @@
     of the category and its items are set by Windows. Items may be added to
     this category indirectly using `app.addRecentDocument(path)`.
   * `custom` - Displays tasks or file links, `name` must be set by the app.
-* `name` String - (optional) Must be set if `type` is `custom`, otherwise it should be
+* `name` String (optional) - Must be set if `type` is `custom`, otherwise it should be
   omitted.
-* `items` JumpListItem[] - (optional) Array of [`JumpListItem`](jump-list-item.md) objects if `type` is `tasks` or
+* `items` JumpListItem[] (optional) - Array of [`JumpListItem`](jump-list-item.md) objects if `type` is `tasks` or
   `custom`, otherwise it should be omitted.
 
 **Note:** If a `JumpListCategory` object has neither the `type` nor the `name`

--- a/test/fixtures/electron/docs/api/structures/jump-list-item.md
+++ b/test/fixtures/electron/docs/api/structures/jump-list-item.md
@@ -1,28 +1,28 @@
 # JumpListItem Object
 
-* `type` String - One of the following:
+* `type` String (optional) - One of the following:
   * `task` - A task will launch an app with specific arguments.
   * `separator` - Can be used to separate items in the standard `Tasks`
     category.
   * `file` - A file link will open a file using the app that created the
     Jump List, for this to work the app must be registered as a handler for
     the file type (though it doesn't have to be the default handler).
-* `path` String - (optional) Path of the file to open, should only be set if `type` is
+* `path` String (optional) - Path of the file to open, should only be set if `type` is
   `file`.
-* `program` String - (optional) Path of the program to execute, usually you should
+* `program` String (optional) - Path of the program to execute, usually you should
   specify `process.execPath` which opens the current program. Should only be
   set if `type` is `task`.
-* `args` String - (optional) The command line arguments when `program` is executed. Should
+* `args` String (optional) - The command line arguments when `program` is executed. Should
   only be set if `type` is `task`.
-* `title` String - (optional) The text to be displayed for the item in the Jump List.
+* `title` String (optional) - The text to be displayed for the item in the Jump List.
   Should only be set if `type` is `task`.
-* `description` String - (optional) Description of the task (displayed in a tooltip).
+* `description` String (optional) - Description of the task (displayed in a tooltip).
   Should only be set if `type` is `task`.
-* `iconPath` String - The absolute path to an icon to be displayed in a
+* `iconPath` String (optional) - The absolute path to an icon to be displayed in a
   Jump List, which can be an arbitrary resource file that contains an icon
   (e.g. `.ico`, `.exe`, `.dll`). You can usually specify `process.execPath` to
   show the program icon.
-* `iconIndex` Number - The index of the icon in the resource file. If a
+* `iconIndex` Number (optional) - The index of the icon in the resource file. If a
   resource file contains multiple icons this value can be used to specify the
   zero-based index of the icon that should be displayed for this task. If a
   resource file contains only one icon, this property should be set to zero.

--- a/test/fixtures/electron/docs/api/structures/memory-usage-details.md
+++ b/test/fixtures/electron/docs/api/structures/memory-usage-details.md
@@ -3,6 +3,3 @@
 * `count` Number
 * `size` Number
 * `liveSize` Number
-* `decodedSize` Number
-* `purgedSize` Number
-* `purgeableSize` Number

--- a/test/fixtures/electron/docs/api/structures/mime-typed-buffer.md
+++ b/test/fixtures/electron/docs/api/structures/mime-typed-buffer.md
@@ -1,0 +1,4 @@
+# MimeTypedBuffer Object
+
+* `mimeType` String - The mimeType of the Buffer that you are sending
+* `buffer` Buffer - The actual Buffer content

--- a/test/fixtures/electron/docs/api/structures/remove-client-certificate.md
+++ b/test/fixtures/electron/docs/api/structures/remove-client-certificate.md
@@ -1,0 +1,5 @@
+# RemoveClientCertificate Object
+
+* `type` String - `clientCertificate`.
+* `origin` String - Origin of the server whose associated client certificate
+  must be removed from the cache.

--- a/test/fixtures/electron/docs/api/structures/remove-password.md
+++ b/test/fixtures/electron/docs/api/structures/remove-password.md
@@ -1,0 +1,15 @@
+# RemovePassword Object
+
+* `type` String - `password`.
+* `origin` String (optional) - When provided, the authentication info
+  related to the origin will only be removed otherwise the entire cache
+  will be cleared.
+* `scheme` String (optional) - Scheme of the authentication.
+  Can be `basic`, `digest`, `ntlm`, `negotiate`. Must be provided if
+  removing by `origin`.
+* `realm` String (optional) - Realm of the authentication. Must be provided if
+  removing by `origin`.
+* `username` String (optional) - Credentials of the authentication. Must be
+  provided if removing by `origin`.
+* `password` String (optional) - Credentials of the authentication. Must be
+  provided if removing by `origin`.

--- a/test/fixtures/electron/docs/api/system-preferences.md
+++ b/test/fixtures/electron/docs/api/system-preferences.md
@@ -2,7 +2,7 @@
 
 > Get system preferences.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 ```javascript
 const {systemPreferences} = require('electron')
@@ -18,7 +18,7 @@ The `systemPreferences` object emits the following events:
 Returns:
 
 * `event` Event
-* `newColor` String - The new RGBA color the user assigned to be there system
+* `newColor` String - The new RGBA color the user assigned to be their system
   accent color.
 
 ### Event: 'color-changed' _Windows_
@@ -114,16 +114,30 @@ Same as `unsubscribeNotification`, but removes the subscriber from `NSNotificati
 
 Get the value of `key` in system preferences.
 
-This API reads from `NSUserDefaults` on macOS, some popular `key` and `type`s
-are:
+This API uses `NSUserDefaults` on macOS. Some popular `key` and `type`s are:
 
-* `AppleInterfaceStyle: string`
-* `AppleAquaColorVariant: integer`
-* `AppleHighlightColor: string`
-* `AppleShowScrollBars: string`
-* `NSNavRecentPlaces: array`
-* `NSPreferredWebServices: dictionary`
-* `NSUserDictionaryReplacementItems: array`
+* `AppleInterfaceStyle`:  `string`
+* `AppleAquaColorVariant`:  `integer`
+* `AppleHighlightColor`:  `string`
+* `AppleShowScrollBars`:  `string`
+* `NSNavRecentPlaces`:  `array`
+* `NSPreferredWebServices`:  `dictionary`
+* `NSUserDictionaryReplacementItems`:  `array`
+
+### `systemPreferences.setUserDefault(key, type, value)` _macOS_
+
+* `key` String
+* `type` String - See [`getUserDefault`][#systempreferencesgetuserdefaultkey-type-macos]
+* `value` String
+
+Set the value of `key` in system preferences.
+
+Note that `type` should match actual type of `value`. An exception is thrown
+if they don't.
+
+This API uses `NSUserDefaults` on macOS. Some popular `key` and `type`s are:
+
+* `ApplePressAndHoldEnabled`:  `boolean`
 
 ### `systemPreferences.isAeroGlassEnabled()` _Windows_
 

--- a/test/fixtures/electron/docs/api/tray.md
+++ b/test/fixtures/electron/docs/api/tray.md
@@ -2,7 +2,7 @@
 
 > Add icons and context menus to the system's notification area.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 `Tray` is an [EventEmitter][event-emitter].
 
@@ -35,18 +35,22 @@ __Platform limitations:__
   you have to call `setContextMenu` again. For example:
 
 ```javascript
-const {Menu, Tray} = require('electron')
-const appIcon = new Tray('/path/to/my/icon')
-const contextMenu = Menu.buildFromTemplate([
-  {label: 'Item1', type: 'radio'},
-  {label: 'Item2', type: 'radio'}
-])
+const {app, Menu, Tray} = require('electron')
 
-// Make a change to the context menu
-contextMenu.items[2].checked = false
+let appIcon = null
+app.on('ready', () => {
+  appIcon = new Tray('/path/to/my/icon')
+  const contextMenu = Menu.buildFromTemplate([
+    {label: 'Item1', type: 'radio'},
+    {label: 'Item2', type: 'radio'}
+  ])
 
-// Call this again for Linux because we modified the context menu
-appIcon.setContextMenu(contextMenu)
+  // Make a change to the context menu
+  contextMenu.items[1].checked = false
+
+  // Call this again for Linux because we modified the context menu
+  appIcon.setContextMenu(contextMenu)
+})
 ```
 * On Windows it is recommended to use `ICO` icons to get best visual effects.
 
@@ -150,7 +154,7 @@ Destroys the tray icon immediately.
 
 #### `tray.setImage(image)`
 
-* `image` [NativeImage](native-image.md)
+* `image` ([NativeImage](native-image.md) | String)
 
 Sets the `image` associated with this tray icon.
 
@@ -206,9 +210,9 @@ win.on('hide', () => {
 #### `tray.displayBalloon(options)` _Windows_
 
 * `options` Object
-  * `icon` [NativeImage](native-image.md)
-  * `title` String
-  * `content` String
+  * `icon` ([NativeImage](native-image.md) | String) - (optional)
+  * `title` String - (optional)
+  * `content` String - (optional)
 
 Displays a tray balloon.
 

--- a/test/fixtures/electron/docs/api/web-contents.md
+++ b/test/fixtures/electron/docs/api/web-contents.md
@@ -2,7 +2,7 @@
 
 > Render and control web pages.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 `webContents` is an
 [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter).
@@ -49,7 +49,7 @@ Returns `WebContents` - A WebContents instance with the given ID.
 
 > Render and control the contents of a BrowserWindow instance.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 ### Instance Events
 
@@ -71,8 +71,6 @@ Returns:
 This event is like `did-finish-load` but emitted when the load failed or was
 cancelled, e.g. `window.stop()` is invoked.
 The full list of error codes and their meaning is available [here](https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h).
-Note that redirect responses will emit `errorCode` -3; you may want to ignore
-that error explicitly.
 
 #### Event: 'did-frame-finish-load'
 
@@ -159,9 +157,20 @@ requested by `window.open` or an external link like `<a target='_blank'>`.
 
 By default a new `BrowserWindow` will be created for the `url`.
 
-Calling `event.preventDefault()` will prevent creating new windows. In such case, the
-`event.newGuest` may be set with a reference to a `BrowserWindow` instance to make it
-used by the Electron's runtime.
+Calling `event.preventDefault()` will prevent Electron from automatically creating a
+new `BrowserWindow`. If you call `event.preventDefault()` and manually create a new
+`BrowserWindow` then you must set `event.newGuest` to reference the new `BrowserWindow`
+instance, failing to do so may result in unexpected behavior. For example:
+
+```javascript
+myBrowserWindow.webContents.on('new-window', (event, url) => {
+  event.preventDefault()
+  const win = new BrowserWindow({show: false})
+  win.once('ready-to-show', () => win.show())
+  win.loadURL(url)
+  event.newGuest = win
+})
+```
 
 #### Event: 'will-navigate'
 
@@ -232,6 +241,25 @@ Emitted when a plugin process has crashed.
 
 Emitted when `webContents` is destroyed.
 
+#### Event: 'before-input-event'
+
+Returns:
+
+* `event` Event
+* `input` Object - Input properties
+  * `type` String - Either `keyUp` or `keyDown`
+  * `key` String - Equivalent to [KeyboardEvent.key][keyboardevent]
+  * `code` String - Equivalent to [KeyboardEvent.code][keyboardevent]
+  * `isAutoRepeat` Boolean - Equivalent to [KeyboardEvent.repeat][keyboardevent]
+  * `shift` Boolean - Equivalent to [KeyboardEvent.shiftKey][keyboardevent]
+  * `control` Boolean - Equivalent to [KeyboardEvent.controlKey][keyboardevent]
+  * `alt` Boolean - Equivalent to [KeyboardEvent.altKey][keyboardevent]
+  * `meta` Boolean - Equivalent to [KeyboardEvent.metaKey][keyboardevent]
+
+Emitted before dispatching the `keydown` and `keyup` events in the page.
+Calling `event.preventDefault` will prevent the page `keydown`/`keyup` events
+from being dispatched.
+
 #### Event: 'devtools-opened'
 
 Emitted when DevTools is opened.
@@ -249,7 +277,7 @@ Emitted when DevTools is focused / opened.
 Returns:
 
 * `event` Event
-* `url` URL
+* `url` String
 * `error` String - The error code
 * `certificate` [Certificate](structures/certificate.md)
 * `callback` Function
@@ -481,16 +509,38 @@ win.webContents.on('paint', (event, dirty, image) => {
 win.loadURL('http://github.com')
 ```
 
+#### Event: 'devtools-reload-page'
+
+Emitted when the devtools window instructs the webContents to reload
+
+#### Event: 'will-attach-webview'
+
+Returns:
+
+* `event` Event
+* `webPreferences` Object - The web preferences that will be used by the guest
+  page. This object can be modified to adjust the preferences for the guest
+  page.
+* `params` Object - The other `<webview>` parameters such as the `src` URL.
+  This object can be modified to adjust the parameters of the guest page.
+
+Emitted when a `<webview>`'s web contents is being attached to this web
+contents. Calling `event.preventDefault()` will destroy the guest page.
+
+This event can be used to configure `webPreferences` for the `webContents`
+of a `<webview>` before it's loaded, and provides the ability to set settings
+that can't be set via `<webview>` attributes.
+
 ### Instance Methods
 
 #### `contents.loadURL(url[, options])`
 
-* `url` URL
+* `url` String
 * `options` Object (optional)
   * `httpReferrer` String (optional) - A HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
-  * `postData` ([UploadRawData](structures/upload-raw-data.md) | [UploadFile](structures/upload-file.md) | [UploadFileSystem](structures/upload-file-system.md) | [UploadBlob](structures/upload-blob.md))[] (optional)
+  * `postData` ([UploadRawData](structures/upload-raw-data.md) | [UploadFile](structures/upload-file.md) | [UploadFileSystem](structures/upload-file-system.md) | [UploadBlob](structures/upload-blob.md))[] - (optional)
 
 Loads the `url` in the window. The `url` must contain the protocol prefix,
 e.g. the `http://` or `file://`. If the load should bypass http cache then
@@ -691,7 +741,22 @@ Sends a request to get current zoom level, the `callback` will be called with
 * `minimumLevel` Number
 * `maximumLevel` Number
 
-Sets the maximum and minimum zoom level.
+**Deprecated:** Call `setVisualZoomLevelLimits` instead to set the visual zoom
+level limits. This method will be removed in Electron 2.0.
+
+#### `contents.setVisualZoomLevelLimits(minimumLevel, maximumLevel)`
+
+* `minimumLevel` Number
+* `maximumLevel` Number
+
+Sets the maximum and minimum pinch-to-zoom level.
+
+#### `contents.setLayoutZoomLevelLimits(minimumLevel, maximumLevel)`
+
+* `minimumLevel` Number
+* `maximumLevel` Number
+
+Sets the maximum and minimum layout-based (i.e. non-visual) zoom level.
 
 #### `contents.undo()`
 
@@ -758,14 +823,14 @@ Inserts `text` to the focused element.
 
 * `text` String - Content to be searched, must not be empty.
 * `options` Object (optional)
-  * `forward` Boolean - Whether to search forward or backward, defaults to `true`.
-  * `findNext` Boolean - Whether the operation is first request or a follow up,
+  * `forward` Boolean - (optional) Whether to search forward or backward, defaults to `true`.
+  * `findNext` Boolean - (optional) Whether the operation is first request or a follow up,
     defaults to `false`.
-  * `matchCase` Boolean - Whether search should be case-sensitive,
+  * `matchCase` Boolean - (optional) Whether search should be case-sensitive,
     defaults to `false`.
-  * `wordStart` Boolean - Whether to look only at the start of words.
+  * `wordStart` Boolean - (optional) Whether to look only at the start of words.
     defaults to `false`.
-  * `medialCapitalAsWordStart` Boolean - When combined with `wordStart`,
+  * `medialCapitalAsWordStart` Boolean - (optional) When combined with `wordStart`,
     accepts a match in the middle of a word if the match begins with an
     uppercase letter followed by a lowercase or non-letter.
     Accepts several other intra-word matches, defaults to `false`.
@@ -841,14 +906,14 @@ Use `page-break-before: always; ` CSS style to force to print to a new page.
 #### `contents.printToPDF(options, callback)`
 
 * `options` Object
-  * `marginsType` Integer - Specifies the type of margins to use. Uses 0 for
+  * `marginsType` Integer - (optional) Specifies the type of margins to use. Uses 0 for
     default margin, 1 for no margin, and 2 for minimum margin.
-  * `pageSize` String - Specify page size of the generated PDF. Can be `A3`,
+  * `pageSize` String - (optional) Specify page size of the generated PDF. Can be `A3`,
     `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`
     and `width` in microns.
-  * `printBackground` Boolean - Whether to print CSS backgrounds.
-  * `printSelectionOnly` Boolean - Whether to print selection only.
-  * `landscape` Boolean - `true` for landscape, `false` for portrait.
+  * `printBackground` Boolean - (optional) Whether to print CSS backgrounds.
+  * `printSelectionOnly` Boolean - (optional) Whether to print selection only.
+  * `landscape` Boolean - (optional) `true` for landscape, `false` for portrait.
 * `callback` Function
   * `error` Error
   * `data` Buffer
@@ -858,6 +923,8 @@ settings.
 
 The `callback` will be called with `callback(error, data)` on completion. The
 `data` is a `Buffer` that contains the generated PDF data.
+
+The `landscape` will be ignored if `@page` CSS at-rule is used in the web page.
 
 By default, an empty `options` will be regarded as:
 
@@ -1095,8 +1162,9 @@ End subscribing for frame presentation events.
 #### `contents.startDrag(item)`
 
 * `item` Object
-  * `file` String
-  * `icon` [NativeImage](native-image.md)
+  * `file` String or `files` Array - The path(s) to the file(s) being dragged.
+  * `icon` [NativeImage](native-image.md) - The image must be non-empty on
+    macOS.
 
 Sets the `item` as dragging item for current drag-drop operation, `file` is the
 absolute path of the file to be dragged, and `icon` is the image showing under
@@ -1112,7 +1180,7 @@ the cursor when dragging.
 * `callback` Function - `(error) => {}`.
   * `error` Error
 
-Returns true if the process of saving page has been initiated successfully.
+Returns `Boolean` - true if the process of saving page has been initiated successfully.
 
 ```javascript
 const {BrowserWindow} = require('electron')
@@ -1130,6 +1198,17 @@ win.webContents.on('did-finish-load', () => {
 #### `contents.showDefinitionForSelection()` _macOS_
 
 Shows pop-up dictionary that searches the selected word on the page.
+
+#### `contents.setSize(options)`
+
+Set the size of the page. This is only supported for `<webview>` guest contents.
+
+* `options` Object
+  * `normal` Object (optional) - Normal size of the page. This can be used in
+    combination with the [`disableguestresize`](web-view-tag.md#disableguestresize)
+    attribute to manually resize the webview guest contents.
+    * `width` Integer
+    * `height` Integer
 
 #### `contents.isOffscreen()`
 
@@ -1160,6 +1239,8 @@ Returns `Integer` - If *offscreen rendering* is enabled returns the current fram
 
 #### `contents.invalidate()`
 
+Schedules a full repaint of the window this web contents is in.
+
 If *offscreen rendering* is enabled invalidates the frame and generates a new
 one through the `'paint'` event.
 
@@ -1187,3 +1268,5 @@ when the DevTools has been closed.
 #### `contents.debugger`
 
 A [Debugger](debugger.md) instance for this webContents.
+
+[keyboardevent]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent

--- a/test/fixtures/electron/docs/api/web-frame.md
+++ b/test/fixtures/electron/docs/api/web-frame.md
@@ -2,7 +2,7 @@
 
 > Customize the rendering of the current web page.
 
-Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+Process: [Renderer](../glossary.md#renderer-process)
 
 An example of zooming current page to 200%.
 
@@ -44,13 +44,30 @@ Returns `Number` - The current zoom level.
 * `minimumLevel` Number
 * `maximumLevel` Number
 
-Sets the maximum and minimum zoom level.
+**Deprecated:** Call `setVisualZoomLevelLimits` instead to set the visual zoom
+level limits. This method will be removed in Electron 2.0.
+
+### `webFrame.setVisualZoomLevelLimits(minimumLevel, maximumLevel)`
+
+* `minimumLevel` Number
+* `maximumLevel` Number
+
+Sets the maximum and minimum pinch-to-zoom level.
+
+### `webFrame.setLayoutZoomLevelLimits(minimumLevel, maximumLevel)`
+
+* `minimumLevel` Number
+* `maximumLevel` Number
+
+Sets the maximum and minimum layout-based (i.e. non-visual) zoom level.
 
 ### `webFrame.setSpellCheckProvider(language, autoCorrectWord, provider)`
 
 * `language` String
 * `autoCorrectWord` Boolean
 * `provider` Object
+  * `spellCheck` Function - Returns `Boolean`
+    * `text` String
 
 Sets a provider for spell checking in input fields and text areas.
 
@@ -112,10 +129,12 @@ webFrame.registerURLSchemeAsPrivileged('foo', { bypassCSP: false })
 
 Inserts `text` to the focused element.
 
-### `webFrame.executeJavaScript(code[, userGesture])`
+### `webFrame.executeJavaScript(code[, userGesture, callback])`
 
 * `code` String
 * `userGesture` Boolean (optional) - Default is `false`.
+* `callback` Function (optional) - Called after script has been executed.
+  * `result` Any
 
 Evaluates `code` in page.
 
@@ -148,10 +167,7 @@ This will generate:
   images: {
     count: 22,
     size: 2549,
-    liveSize: 2542,
-    decodedSize: 478,
-    purgedSize: 0,
-    purgeableSize: 0
+    liveSize: 2542
   },
   cssStyleSheets: { /* same with "images" */ },
   xslStyleSheets: { /* same with "images" */ },

--- a/test/fixtures/electron/docs/api/web-request.md
+++ b/test/fixtures/electron/docs/api/web-request.md
@@ -2,7 +2,7 @@
 
 > Intercept and modify the contents of a request at various stages of its lifetime.
 
-Process: [Main](../tutorial/quick-start.md#main-process)
+Process: [Main](../glossary.md#main-process)
 
 Instances of the `WebRequest` class are accessed by using the `webRequest`
 property of a `Session`.

--- a/test/fixtures/electron/docs/api/webview-tag.md
+++ b/test/fixtures/electron/docs/api/webview-tag.md
@@ -2,6 +2,8 @@
 
 > Display external web content in an isolated frame and process.
 
+Process: [Renderer](../tutorial/quick-start.md#renderer-process)
+
 Use the `webview` tag to embed 'guest' content (such as web pages) in your
 Electron app. The guest content is contained within the `webview` container.
 An embedded page within your app controls how the guest content is laid out and
@@ -535,20 +537,42 @@ Stops any `findInPage` request for the `webview` with the provided `action`.
 
 ### `<webview>.print([options])`
 
+* `options` Object (optional)
+  * `silent` Boolean - Don't ask user for print settings. Default is `false`.
+  * `printBackground` Boolean - Also prints the background color and image of
+    the web page. Default is `false`.
+
 Prints `webview`'s web page. Same as `webContents.print([options])`.
 
 ### `<webview>.printToPDF(options, callback)`
 
+* `options` Object
+  * `marginsType` Integer - (optional) Specifies the type of margins to use. Uses 0 for
+    default margin, 1 for no margin, and 2 for minimum margin.
+  * `pageSize` String - (optional) Specify page size of the generated PDF. Can be `A3`,
+    `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`
+    and `width` in microns.
+  * `printBackground` Boolean - (optional) Whether to print CSS backgrounds.
+  * `printSelectionOnly` Boolean - (optional) Whether to print selection only.
+  * `landscape` Boolean - (optional) `true` for landscape, `false` for portrait.
+* `callback` Function
+  * `error` Error
+  * `data` Buffer
+
 Prints `webview`'s web page as PDF, Same as `webContents.printToPDF(options, callback)`.
 
 ### `<webview>.capturePage([rect, ]callback)`
+
+* `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured
+* `callback` Function
+  * `image` [NativeImage](native-image.md)
 
 Captures a snapshot of the `webview`'s page. Same as `webContents.capturePage([rect, ]callback)`.
 
 ### `<webview>.send(channel[, arg1][, arg2][, ...])`
 
 * `channel` String
-* `arg` (optional)
+* `...args` any[]
 
 Send an asynchronous message to renderer process via `channel`, you can also
 send arbitrary arguments. The renderer process can handle the message by

--- a/test/fixtures/electron/docs/api/webview-tag.md
+++ b/test/fixtures/electron/docs/api/webview-tag.md
@@ -35,7 +35,7 @@ and displays a "loading..." message during the load time:
 ```html
 <script>
   onload = () => {
-    const webview = document.getElementById('foo')
+    const webview = document.querySelector('webview')
     const indicator = document.querySelector('.indicator')
 
     const loadstart = () => {
@@ -103,14 +103,15 @@ The `src` attribute can also accept data URLs, such as
 ### `autosize`
 
 ```html
-<webview src="https://www.github.com/" autosize="on" minwidth="576" minheight="432"></webview>
+<webview src="https://www.github.com/" autosize minwidth="576" minheight="432"></webview>
 ```
 
-If "on", the `webview` container will automatically resize within the
-bounds specified by the attributes `minwidth`, `minheight`, `maxwidth`, and
-`maxheight`. These constraints do not impact the `webview` unless `autosize` is
-enabled. When `autosize` is enabled, the `webview` container size cannot be less
-than the minimum values or greater than the maximum.
+When this attribute is present the `webview` container will automatically resize
+within the bounds specified by the attributes `minwidth`, `minheight`,
+`maxwidth`, and `maxheight`. These constraints do not impact the `webview`
+unless `autosize` is enabled. When `autosize` is enabled, the `webview`
+container size cannot be less than the minimum values or greater than the
+maximum.
 
 ### `nodeintegration`
 
@@ -118,8 +119,10 @@ than the minimum values or greater than the maximum.
 <webview src="http://www.google.com/" nodeintegration></webview>
 ```
 
-If "on", the guest page in `webview` will have node integration and can use node
-APIs like `require` and `process` to access low level system resources.
+When this attribute is present the guest page in `webview` will have node
+integration and can use node APIs like `require` and `process` to access low
+level system resources. Node integration is disabled by default in the guest
+page.
 
 ### `plugins`
 
@@ -127,7 +130,8 @@ APIs like `require` and `process` to access low level system resources.
 <webview src="https://www.github.com/" plugins></webview>
 ```
 
-If "on", the guest page in `webview` will be able to use browser plugins.
+When this attribute is present the guest page in `webview` will be able to use
+browser plugins. Plugins are disabled by default.
 
 ### `preload`
 
@@ -166,7 +170,8 @@ page is loaded, use the `setUserAgent` method to change the user agent.
 <webview src="https://www.github.com/" disablewebsecurity></webview>
 ```
 
-If "on", the guest page will have web security disabled.
+When this attribute is present the guest page will have web security disabled.
+Web security is enabled by default.
 
 ### `partition`
 
@@ -192,12 +197,13 @@ value will fail with a DOM exception.
 <webview src="https://www.github.com/" allowpopups></webview>
 ```
 
-If "on", the guest page will be allowed to open new windows.
+When this attribute is present the guest page will be allowed to open new
+windows. Popups are disabled by default.
 
 ### `webpreferences`
 
 ```html
-<webview src="https://github.com" webpreferences="allowDisplayingInsecureContent, javascript=no"></webview>
+<webview src="https://github.com" webpreferences="allowRunningInsecureContent, javascript=no"></webview>
 ```
 
 A list of strings which specifies the web preferences to be set on the webview, separated by `,`.
@@ -206,7 +212,7 @@ The full list of supported preference strings can be found in [BrowserWindow](br
 The string follows the same format as the features string in `window.open`.
 A name by itself is given a `true` boolean value.
 A preference can be set to another value by including an `=`, followed by the value.
-Special values `yes` and `1` are interpreted as `true`, while `no` and `0` are interpreted as `false`.  
+Special values `yes` and `1` are interpreted as `true`, while `no` and `0` are interpreted as `false`.
 
 ### `blinkfeatures`
 
@@ -216,7 +222,7 @@ Special values `yes` and `1` are interpreted as `true`, while `no` and `0` are i
 
 A list of strings which specifies the blink features to be enabled separated by `,`.
 The full list of supported feature strings can be found in the
-[RuntimeEnabledFeatures.in][blink-feature-string] file.
+[RuntimeEnabledFeatures.json5][blink-feature-string] file.
 
 ### `disableblinkfeatures`
 
@@ -226,7 +232,7 @@ The full list of supported feature strings can be found in the
 
 A list of strings which specifies the blink features to be disabled separated by `,`.
 The full list of supported feature strings can be found in the
-[RuntimeEnabledFeatures.in][blink-feature-string] file.
+[RuntimeEnabledFeatures.json5][blink-feature-string] file.
 
 ### `guestinstance`
 
@@ -243,6 +249,44 @@ webview.
 The existing webview will see the `destroy` event and will then create a new
 webContents when a new url is loaded.
 
+### `disableguestresize`
+
+```html
+<webview src="https://www.github.com/" disableguestresize></webview>
+```
+
+When this attribute is present the `webview` contents will be prevented from
+resizing when the `webview` element itself is resized.
+
+This can be used in combination with
+[`webContents.setSize`](web-contents.md#contentssetsizeoptions) to manually
+resize the webview contents in reaction to a window size change. This can
+make resizing faster compared to relying on the webview element bounds to
+automatically resize the contents.
+
+```javascript
+const {webContents} = require('electron')
+
+// We assume that `win` points to a `BrowserWindow` instance containing a
+// `<webview>` with `disableguestresize`.
+
+win.on('resize', () => {
+  const [width, height] = win.getContentSize()
+  for (let wc of webContents.getAllWebContents()) {
+    // Check if `wc` belongs to a webview in the `win` window.
+    if (wc.hostWebContents &&
+        wc.hostWebContents.id === win.webContents.id) {
+      wc.setSize({
+        normal: {
+          width: width,
+          height: height
+        }
+      })
+    }
+  }
+})
+```
+
 ## Methods
 
 The `webview` tag has the following methods:
@@ -252,7 +296,7 @@ The `webview` tag has the following methods:
 **Example**
 
 ```javascript
-const webview = document.getElementById('foo')
+const webview = document.querySelector('webview')
 webview.addEventListener('dom-ready', () => {
   webview.openDevTools()
 })
@@ -265,7 +309,7 @@ webview.addEventListener('dom-ready', () => {
   * `httpReferrer` String (optional) - A HTTP Referrer url.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
-  * `postData` ([UploadRawData](structures/upload-raw-data.md) | [UploadFile](structures/upload-file.md) | [UploadFileSystem](structures/upload-file-system.md) | [UploadBlob](structures/upload-blob.md))[] (optional)
+  * `postData` ([UploadRawData](structures/upload-raw-data.md) | [UploadFile](structures/upload-file.md) | [UploadFileSystem](structures/upload-file-system.md) | [UploadBlob](structures/upload-blob.md))[] - (optional)
 
 Loads the `url` in the webview, the `url` must contain the protocol prefix,
 e.g. the `http://` or `file://`.
@@ -477,12 +521,12 @@ Inserts `text` to the focused element.
 
 Starts a request to find all matches for the `text` in the web page and returns an `Integer`
 representing the request id used for the request. The result of the request can be
-obtained by subscribing to [`found-in-page`](web-view-tag.md#event-found-in-page) event.
+obtained by subscribing to [`found-in-page`](webview-tag.md#event-found-in-page) event.
 
 ### `<webview>.stopFindInPage(action)`
 
 * `action` String - Specifies the action to take place when ending
-  [`<webview>.findInPage`](web-view-tag.md#webviewtagfindinpage) request.
+  [`<webview>.findInPage`](webview-tag.md#webviewtagfindinpage) request.
   * `clearSelection` - Clear the selection.
   * `keepSelection` - Translate the selection into a normal selection.
   * `activateSelection` - Focus and click the selection node.
@@ -543,7 +587,8 @@ Shows pop-up dictionary that searches the selected word on the page.
 
 ### `<webview>.getWebContents()`
 
-Returns `WebContents` - The [WebContents](web-contents.md) associated with this `webview`.
+Returns [`WebContents`](web-contents.md) - The web contents associated with
+this `webview`.
 
 ## DOM events
 
@@ -664,7 +709,7 @@ The following example code forwards all log messages to the embedder's console
 without regard for log level or other properties.
 
 ```javascript
-const webview = document.getElementById('foo')
+const webview = document.querySelector('webview')
 webview.addEventListener('console-message', (e) => {
   console.log('Guest page logged a message:', e.message)
 })
@@ -681,10 +726,10 @@ Returns:
   * `selectionArea` Object - Coordinates of first match region.
 
 Fired when a result is available for
-[`webview.findInPage`](web-view-tag.md#webviewtagfindinpage) request.
+[`webview.findInPage`](webview-tag.md#webviewtagfindinpage) request.
 
 ```javascript
-const webview = document.getElementById('foo')
+const webview = document.querySelector('webview')
 webview.addEventListener('found-in-page', (e) => {
   webview.stopFindInPage('keepSelection')
 })
@@ -710,7 +755,7 @@ The following example code opens the new url in system's default browser.
 
 ```javascript
 const {shell} = require('electron')
-const webview = document.getElementById('foo')
+const webview = document.querySelector('webview')
 
 webview.addEventListener('new-window', (e) => {
   const protocol = require('url').parse(e.url).protocol
@@ -771,7 +816,7 @@ The following example code navigates the `webview` to `about:blank` when the
 guest attempts to close itself.
 
 ```javascript
-const webview = document.getElementById('foo')
+const webview = document.querySelector('webview')
 webview.addEventListener('close', () => {
   webview.src = 'about:blank'
 })
@@ -791,7 +836,7 @@ between guest page and embedder page:
 
 ```javascript
 // In embedder page.
-const webview = document.getElementById('foo')
+const webview = document.querySelector('webview')
 webview.addEventListener('ipc-message', (event) => {
   console.log(event.channel)
   // Prints "pong"
@@ -868,4 +913,4 @@ Emitted when DevTools is closed.
 
 Emitted when DevTools is focused / opened.
 
-[blink-feature-string]: https://cs.chromium.org/chromium/src/third_party/WebKit/Source/platform/RuntimeEnabledFeatures.in
+[blink-feature-string]: https://cs.chromium.org/chromium/src/third_party/WebKit/Source/platform/RuntimeEnabledFeatures.json5?l=62

--- a/test/fixtures/electron/docs/api/window-open.md
+++ b/test/fixtures/electron/docs/api/window-open.md
@@ -20,7 +20,8 @@ string.
 * `frameName` String (optional)
 * `features` String (optional)
 
-Returns `BrowserWindowProxy` - Creates a new window and returns an instance of `BrowserWindowProxy` class.
+Returns [`BrowserWindowProxy`](browser-window-proxy.md) - Creates a new window
+and returns an instance of `BrowserWindowProxy` class.
 
 The `features` string follows the format of standard browser, but each feature
 has to be a field of `BrowserWindow`'s options.

--- a/test/index.js
+++ b/test/index.js
@@ -143,6 +143,16 @@ describe('APIs', function () {
       })
       expect(assertions).to.be.above(80)
     })
+
+    they('exist on the webviewTag API', function () {
+      expect(apis.webviewTag.methods).to.exist
+      expect(apis.webviewTag.methods).to.be.an('array')
+      expect(apis.webviewTag.methods.length).to.be.above(5)
+      apis.webviewTag.methods.forEach(method => {
+        expect(method.name).to.exist
+        expect(method.description).to.exist
+      })
+    })
   })
 
   describe('Parameters', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -435,6 +435,13 @@ describe('APIs', function () {
     })
   })
 
+  describe('Attributes', function () {
+    they('exist on the webviewTag API', function () {
+      console.log(apis.webviewTag.attributes)
+      expect(apis.webviewTag.attributes).to.exist
+    })
+  })
+
   describe('Convenience URLs', function () {
     it('sets a websiteUrl', function () {
       var url = 'http://electron.atom.io/docs/api/tray'

--- a/test/index.js
+++ b/test/index.js
@@ -513,4 +513,10 @@ describe('APIs', function () {
       })
     })
   })
+
+  describe('Elements', function () {
+    they('have a type property of `Element`', function () {
+      expect(apis.webviewTag.type).to.eq('Element')
+    })
+  })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -437,8 +437,13 @@ describe('APIs', function () {
 
   describe('Attributes', function () {
     they('exist on the webviewTag API', function () {
-      console.log(apis.webviewTag.attributes)
       expect(apis.webviewTag.attributes).to.exist
+      expect(apis.webviewTag.attributes).to.be.an('array')
+      expect(apis.webviewTag.attributes.length).to.be.above(5)
+      apis.webviewTag.attributes.forEach(attr => {
+        expect(attr.name).to.exist
+        expect(attr.description).to.exist
+      })
     })
   })
 


### PR DESCRIPTION
This PR adds a new subclass of the `Collection` parser for collecting all the attributes of the `<webview>` tag: https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#tag-attributes

It also removes some code that used to attach DOM ids to all the headings to make them searchable. That code existed to work around the fact that multiple APIs were defined in the same markdown file. Now there is [One File Per API](https://github.com/electron/electron-docs-linter/pull/77), so this special tagging stuff is no longer needed.

See also this companion PR that fixes some formatting issues in the docs: https://github.com/electron/electron/pull/8816

cc @MarshallOfSound 