### PR TITLE
derive instanceName from name if needed

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -182,8 +182,16 @@ class API {
   parseInstanceName () {
     if (this.name === 'webviewTag') return 'webview'
 
+    // Some classes don't have any instance events/methods/properties from
+    // which to infer an instance name. In that case, derive it from the name.
+    // TouchBarGroup -> touchBarGroup
+    if (!this.instanceEvents.length && !this.instanceMethods.length && !this.instanceProperties.length) {
+      return this.name.charAt(0).toLowerCase() + this.name.slice(1)
+    }
+
     var $heading = (this.$('[id$="instance-methods"]'))
     if (!$heading.length) $heading = this.$('[id$="instance-properties"]')
+    if (!$heading.length) $heading = this.$('[id$="instance-events"]')
     if (!$heading.length) return
 
     $heading = $heading

--- a/test/fixtures/electron/docs/api/touch-bar-group.md
+++ b/test/fixtures/electron/docs/api/touch-bar-group.md
@@ -1,0 +1,10 @@
+## Class: TouchBarGroup
+
+> Create a group in the touch bar for native macOS applications
+
+Process: [Main](../tutorial/quick-start.md#main-process)
+
+### `new TouchBarGroup(options)`
+
+* `options` Object
+  * `items` TouchBar - Items to display as a group.

--- a/test/index.js
+++ b/test/index.js
@@ -111,6 +111,11 @@ describe('APIs', function () {
       expect(classes.every(api => api.instanceName.length > 0)).to.equal(true)
       expect(apis.BrowserWindow.instanceName).to.equal('win')
     })
+
+    they('derive instanceName from name if no instance events/methods/properties exist', function () {
+      expect(apis.TouchBarGroup).to.exist
+      expect(apis.TouchBarGroup.instanceName).to.eq('touchBarGroup')
+    })
   })
 
   describe('Methods', function () {


### PR DESCRIPTION
There are some new [TouchBar APIs being added](https://github.com/electron/electron/pull/8095/commits/a52073867cd48152b44fbf5eefbd18d7c7e02d12) that are `Class`es without instance events/methods/properties from which to derive the `instanceName` string property.

This PR ensures that such classes will get an `instanceName` derived from their `name`, e.g. `TouchBarGroup` → `touchBarGroup`

cc @kevinsawicki 