### PR TITLE
Include `required` key for all parameters and properties

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -27,6 +27,7 @@ class API {
           subObjects[name] = {
             name,
             type: 'Object',
+            required: true,
             properties: []
           }
         }

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -53,7 +53,7 @@ const sanitizeDescription = (description) => {
     .replace(/ - /gi, ' ') // remove spaced dashes
     .replace(/\n/g, ' ') // newlines to spaces
     .replace(/\s+/g, ' ') // remove extra spaces
-    .replace(/^\s+?\(optional\)/gi, '') // remove (optional) notation, because it is parsed as a boolean
+    .replace(/^\s*\(optional\)/gi, '') // remove (optional) notation, because it is parsed as a boolean
     .trim()
   )
 }
@@ -119,7 +119,8 @@ const generateObjectProps = ($, topUL, api) => {
         name: match[1],
         type: stripArrTags(multitypify(match[2])),
         collection: match[2].endsWith('[]') || (typeof multitypify(match[2]) === 'string' && multitypify(match[2]).endsWith('[]')),
-        description: sanitizeDescription(description)
+        description: sanitizeDescription(description),
+        required: !description.match(/\(optional\)/i)
       }
 
       if (ret.type === 'Object') {
@@ -247,13 +248,8 @@ module.exports = {
           name: match[1],
           type: stripArrTags(multitypify(match[2])),
           collection: match[2].endsWith('[]') || (typeof multitypify(match[2]) === 'string' && multitypify(match[2]).endsWith('[]')),
-          description: sanitizeDescription(description)
-        }
-
-        // Look for (optional) string in the description of all parameters,
-        // except for event params, where optional/required does not apply.
-        if (!openingHeadingElement.html().match(/^Event/)) {
-          arg.required = !description.match(/\(optional\)/i)
+          description: sanitizeDescription(description),
+          required: !description.match(/\(optional\)/i)
         }
 
         if (arg.type === 'Object') {

--- a/lib/property.js
+++ b/lib/property.js
@@ -7,7 +7,7 @@ const pattern = /<code>.*?\.(?:(\w+)\.)?(\w+)<\/code>/
 const typePattern = /An? ([a-zA-Z]+(?:\[])?) ?/
 const props = ['name', 'description', 'type', 'collection', '_superObject']
 
-module.exports = class Event extends CollectionItem {
+module.exports = class Property extends CollectionItem {
   constructor (api, el) {
     super(api, el, pattern, props)
 

--- a/test/index.js
+++ b/test/index.js
@@ -178,11 +178,11 @@ describe('APIs', function () {
       expect(method.description).to.equal('The extra size not to be included while maintaining the aspect ratio.')
     })
 
-    they('do not have a `required` key if they are for an event', function () {
+    they('have a `required` key for events', function () {
       var keys = Object.keys(apis.app.events.activate.returns.hasVisibleWindows)
       expect(keys).to.include('name')
       expect(keys).to.include('type')
-      expect(keys).to.not.include('required')
+      expect(keys).to.include('required')
     })
 
     they('do not contain HTML encoded characters', function () {
@@ -340,6 +340,12 @@ describe('APIs', function () {
       expect(param.parameters[1].parameters[0].type).to.equal('Object')
       expect(param.parameters[1].parameters[0].properties).to.exist
       expect(param.parameters[1].parameters[0].properties[0].type).to.equal('Boolean')
+    })
+  })
+
+  describe('Properties', function () {
+    they('are marked `required` for super objects', function () {
+      apis.app.properties.forEach(prop => expect(prop.required).to.equal(true))
     })
   })
 
@@ -516,6 +522,7 @@ describe('APIs', function () {
       structs.forEach(struct => {
         expect(struct.properties).to.exist
         expect(struct.properties.length).to.be.gt(0)
+        struct.properties.forEach(prop => expect(prop.required).to.exist)
       })
     })
   })


### PR DESCRIPTION
This is needed to correctly identify optional parameters and properties
in electron/electron-typescript-definitions.

cc @zeke @MarshallOfSound