### PR TITLE
Update URLs to electronjs.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ electron-docs-linter path/to/electron/docs
 If errors are found, they are printed to STDERR and the process
 exits un-gracefully.
 
-To lint the docs and save the generated [JSON schema](http://electron.atom.io/blog/2016/09/27/api-docs-json-schema) to a file:
+To lint the docs and save the generated [JSON schema](http://electronjs.org/blog/2016/09/27/api-docs-json-schema) to a file:
 
 ```sh
 electron-docs-linter docs/api --version=1.2.3 --outfile=api.json

--- a/lib/api.js
+++ b/lib/api.js
@@ -13,7 +13,7 @@ class API {
   constructor (props, docs) {
     Object.assign(this, props)
     this.slug = this.parseSlug()
-    this.websiteUrl = `http://electron.atom.io/docs/api/${props.structure ? 'structures/' : ''}${this.slug}`
+    this.websiteUrl = `http://electronjs.org/docs/api/${props.structure ? 'structures/' : ''}${this.slug}`
     this.repoUrl = `https://github.com/electron/electron/blob/v${this.version}/docs/api/${props.structure ? 'structures/' : ''}${this.slug}.md`
     this.type = this.parseType(props)
     this.parseDoc(docs)

--- a/test/fixtures/electron/docs/api/clipboard.md
+++ b/test/fixtures/electron/docs/api/clipboard.md
@@ -103,7 +103,7 @@ clipboard.
 
 ```js
 clipboard.write({
-  text: 'http://electron.atom.io',
+  text: 'http://electronjs.org',
   bookmark: 'Electron Homepage'
 })
 ```

--- a/test/fixtures/electron/docs/api/menu.md
+++ b/test/fixtures/electron/docs/api/menu.md
@@ -192,7 +192,7 @@ const template = [
     submenu: [
       {
         label: 'Learn More',
-        click () { require('electron').shell.openExternal('http://electron.atom.io') }
+        click () { require('electron').shell.openExternal('http://electronjs.org') }
       }
     ]
   }

--- a/test/fixtures/electron/docs/api/webview-tag.md
+++ b/test/fixtures/electron/docs/api/webview-tag.md
@@ -179,7 +179,7 @@ Web security is enabled by default.
 
 ```html
 <webview src="https://github.com" partition="persist:github"></webview>
-<webview src="http://electron.atom.io" partition="electron"></webview>
+<webview src="http://electronjs.org" partition="electron"></webview>
 ```
 
 Sets the session used by the page. If `partition` starts with `persist:`, the

--- a/test/index.js
+++ b/test/index.js
@@ -474,7 +474,7 @@ describe('APIs', function () {
 
   describe('Convenience URLs', function () {
     it('sets a websiteUrl', function () {
-      var url = 'http://electron.atom.io/docs/api/tray'
+      var url = 'http://electronjs.org/docs/api/tray'
       expect(apis.Tray.websiteUrl).to.equal(url)
     })
 


### PR DESCRIPTION
The `websiteUrl` that ends up throughout `electron-api.json` was my main target but I replaced all the other instances of the old urls too.