### PR TITLE
feat: add support for "extends" in structures

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,13 +78,14 @@ function deriveSeeds (docs) {
       const moduleHeading = /^# (.*)/
       const moduleHeadingMatch = doc.markdown_content.match(moduleHeading)
       if (moduleHeadingMatch) {
-        var name = moduleHeadingMatch[1].replace(/ Object/, '')
+        var name = moduleHeadingMatch[1].replace(/ Object/, '').replace(/ extends .+/, '')
 
         // Special case for '<webview> Tag' heading
         if (name.match(/webview/i)) name = 'webviewTag'
 
         seeds.push({
           name: name,
+          moduleLevelHeading: moduleHeadingMatch[1],
           structure: !!doc.filename.match('structures')
         })
       }

--- a/lib/api.js
+++ b/lib/api.js
@@ -69,6 +69,13 @@ class API {
 
     if (this.type === 'Structure') {
       this.properties = parsers.generateObjectProps(this.$, this.$('ul').first(), this)
+
+      if (this.moduleLevelHeading) {
+        const extendsMatch = this.moduleLevelHeading.match(/.+extends `(.+?)`/)
+        if (extendsMatch) {
+          this.extends = extendsMatch[1]
+        }
+      }
     }
   }
 
@@ -144,7 +151,8 @@ class API {
       'instanceEvents',
       'properties',
       'attributes',
-      'domEvents'
+      'domEvents',
+      'extends'
     ]
 
     return cleanDeep(pick(this, props))

--- a/test/fixtures/electron/docs/api/structures/event.md
+++ b/test/fixtures/electron/docs/api/structures/event.md
@@ -1,0 +1,10 @@
+# Event Object extends `GlobalEvent`
+
+* `preventDefault` Function
+* `sender` WebContents
+* `returnValue` any
+* `ctrlKey` Boolean (optional) - whether the Control key was used in an accelerator to trigger the Event
+* `metaKey` Boolean (optional) - whether a meta key was used in an accelerator to trigger the Event
+* `shiftKey` Boolean (optional) - whether a Shift key was used in an accelerator to trigger the Event
+* `altKey` Boolean (optional) - whether an Alt key was used in an accelerator to trigger the Event
+* `triggeredByAccelerator` Boolean (optional) - whether an accelerator was used to trigger the event as opposed to another user gesture like mouse click

--- a/test/index.js
+++ b/test/index.js
@@ -599,6 +599,12 @@ describe('APIs', function () {
         struct.properties.forEach(prop => expect(prop.required).to.exist)
       })
     })
+
+    it('should have "extends" for structures that extend other structures', () => {
+      expect(apis.Event).to.have.property('extends')
+        .that.is.a('string')
+        .and.is.equal('GlobalEvent')
+    })
   })
 
   describe('Elements', function () {


### PR DESCRIPTION
Add support for "extends" in API structures of our documentation so that we don't have to hardcode as many interfaces in `electron-typescript-definitions`.

Co-authored-by: Shelley Vohr <shelley.vohr@gmail.com>