### PR TITLE
feat: add support for multi-inner Generics

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -4,9 +4,9 @@ const cheerio = require('cheerio')
 const cleanDeep = require('clean-deep')
 const entities = require('entities')
 
-const parameterPattern = /<code>((?:...)?\w+?)<\/code>\s*(\(?(?:(?:(?:<a href.*?>)?[a-zA-Z0-9[\]]+(?:<(?:[a-zA-Z[\]]+(?: \| )?)+>)?(?:<\/a>)?(?: \| )?)+)\)?(?:\[])?)(?: - )?([\s\S]*)/m
+const parameterPattern = /<code>((?:...)?\w+?)<\/code>\s*(\(?(?:(?:(?:<a href.*?>)?[a-zA-Z0-9[\]]+(?:<(?:[a-zA-Z[\]]+(?:(?: \| )|(?:, ))?)+>)?(?:<\/a>)?(?: \| )?)+)\)?(?:\[])?)(?: - )?([\s\S]*)/m
 const methodReturnPattern = /^Returns (<a.+?>)?<code>(.*?)<\/code>(<\/a>)?/g
-const multiTypePattern = /(?:<a href.*?>)?([a-zA-Z0-9[\]]+(?:<(?:[a-zA-Z[\]]+(?: \| )?)+>)?)(?:<\/a>)?(?: \| )?/mg
+const multiTypePattern = /(?:<a href.*?>)?([a-zA-Z0-9[\]]+(?:<(?:[a-zA-Z[\]]+(?:(?: \| )|(?:, ))?)+>)?)(?:<\/a>)?(?: \| )?/mg
 const innerTypePattern = /([a-zA-Z0-9]+)(?:<(.+)>)?/g
 
 const stripArrTags = (type) => {
@@ -31,7 +31,8 @@ const getInnerType = (type) => {
     if (!outer) throw new Error('Outer type should never be null but it was for: ' + type)
     var inner = execResult[2]
     if (inner) {
-      inner = stripArrTags(multitypify(inner))
+      // Handle multi-inners
+      inner = inner.split(', ').map(t => stripArrTags(multitypify(t)))
     }
     return { outer, inner }
   }

--- a/test/fixtures/electron/docs/api/crash-reporter.md
+++ b/test/fixtures/electron/docs/api/crash-reporter.md
@@ -43,7 +43,7 @@ The `crashReporter` module has the following methods:
   * `uploadToServer` Boolean (optional) _macOS_ - Whether crash reports should be sent to the server
     Default is `true`.
   * `ignoreSystemCrashHandler` Boolean (optional) - Default is `false`.
-  * `extra` Object (optional) - An object you can define that will be sent along with the
+  * `extra` Record<string, string> (optional) - An object you can define that will be sent along with the
     report. Only string properties are sent correctly. Nested objects are not
     supported.
 

--- a/test/index.js
+++ b/test/index.js
@@ -167,13 +167,13 @@ describe('APIs', function () {
     they('can return promises with inner types', function () {
       expect(apis.app.methods.isDefaultProtocolClient).to.exist()
       expect(apis.app.methods.isDefaultProtocolClient.returns.type).to.eq('Promise')
-      expect(apis.app.methods.isDefaultProtocolClient.returns.innerType).to.eq('boolean')
+      expect(apis.app.methods.isDefaultProtocolClient.returns.innerType[0]).to.eq('boolean')
     })
 
     they('can return promises with complex inner types', function () {
       expect(apis.app.methods.removeAsDefaultProtocolClient).to.exist()
       expect(apis.app.methods.removeAsDefaultProtocolClient.returns.type).to.eq('Promise')
-      expect(apis.app.methods.removeAsDefaultProtocolClient.returns.innerType).to.deep.eq([
+      expect(apis.app.methods.removeAsDefaultProtocolClient.returns.innerType[0]).to.deep.eq([
         {
           collection: false,
           innerType: undefined,
@@ -312,7 +312,7 @@ describe('APIs', function () {
     they('can be promises with inner types', function () {
       var param = apis.app.methods.isDefaultProtocolClient.parameters[0]
       expect(param.type).to.eq('Promise')
-      expect(param.innerType).to.eq('String')
+      expect(param.innerType[0]).to.eq('String')
     })
   })
 
@@ -409,7 +409,7 @@ describe('APIs', function () {
     they('can be promises with inner types', function () {
       var prop = apis.BrowserWindow.instanceProperties.id
       expect(prop.type).to.eq('Promise')
-      expect(prop.innerType).to.eq('Integer')
+      expect(prop.innerType[0]).to.eq('Integer')
     })
   })
 
@@ -559,7 +559,16 @@ describe('APIs', function () {
       const prop = method.returns.properties[0]
       expect(prop.name).to.eq('x')
       expect(prop.type).to.eq('Promise')
-      expect(prop.innerType).to.eq('Integer')
+      expect(prop.innerType[0]).to.eq('Integer')
+    })
+
+    it('resolves multi-inner generics as innerTypes', function () {
+      const method = apis.crashReporter.methods.start
+      const options = method.parameters.options
+      expect(options.properties.extra.innerType).to.deep.equal([
+        'string',
+        'string'
+      ])
     })
   })
 


### PR DESCRIPTION
BREAKING CHANGE: innerType is now an array of innerTypes

We now support `Record<string, string>` (and other multi-inner generics
like `Map`)

This requires a corresponding change in `electron-typescript-definitions`