### PR TITLE
fix: parsing error logging `[object Object]`

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -261,7 +261,7 @@ module.exports = {
         if (!match) {
           console.error('problem parsing parameters')
           console.error(`parameterPattern: ${parameterPattern}`)
-          console.error(`el: ${el}`)
+          console.error($(el).text())
           return
         }
 


### PR DESCRIPTION
Came across this issue running `npm run create-api-json` in the electron repo.

Instead of the output saying
```
problem parsing parameters
parameterPattern: /<code>((?:...)?\w+?)<\/code>\s*(\(?(?:(?:(?:<a href.*?>)?[a-zA-Z0-9[\]]+(?:<(?:[a-zA-Z[\]]+(?: \| )?)+>)?(?:<\/a>)?(?: \| )?)+)\)?(?:\[])?)(?: - )?([\s\S]*)/m
el: [object Object]
```

It will now say something like
```
problem parsing parameters
parameterPattern: /<code>((?:...)?\w+?)<\/code>\s*(\(?(?:(?:(?:<a href.*?>)?[a-zA-Z0-9[\]]+(?:<(?:[a-zA-Z[\]]+(?: \| )?)+>)?(?:<\/a>)?(?: \| )?)+)\)?(?:\[])?)(?: - )?([\s\S]*)/m

Returns Promise<NativeImage> - Resolves with a NativeImage
```